### PR TITLE
feat: add DeepSeek/Mistral/OpenAI-compatible providers and model CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,9 @@ parserFallbacks: {
 | **Anthropic** | Claude Opus 4.6, Claude Sonnet 4.6, Claude Haiku 4.5 | -- (use separate provider) | Long context (1M), coding, analysis |
 | **Google** | Gemini 3.1 Pro, Gemini 3.1 Flash Lite, Gemini 3.0 Deep Think | text-embedding-005 | Multimodal, multilingual |
 | **xAI** | Grok 4, Grok 4 Heavy, Grok 4.1 Fast | Grok embedding | Real-time knowledge, code |
+| **DeepSeek** | DeepSeek-V3.2, DeepSeek-R1, DeepSeek-V4 (upcoming) | -- (use separate provider) | Cost-efficient reasoning, 164K context |
+| **Mistral** | Mistral Small 4 (MoE), Large 2.1, Codestral, Pixtral | mistral-embed (1024) | European data residency, coding, vision |
+| **OpenAI-compatible** | Any OpenAI-compatible endpoint | Depends on endpoint | vLLM, LM Studio, Together, Fireworks, Groq, DeepInfra, SiliconFlow, OpenRouter |
 
 ### Local Models (via Ollama)
 
@@ -275,6 +278,7 @@ parserFallbacks: {
 | **Llama 4 Scout** | 17B (MoE) | 109B | Yes | Good | 10M context window |
 | **Llama 4 Maverick** | 17B (MoE) | 400B | Yes | Good | Top open-source quality |
 | **DeepSeek V3.2** | 37B (MoE) | 671B | No | Good | Coding, reasoning |
+| **Gemma 4** | 27B / 12B / 4B / 1B | dense | Yes | Good | Latest Google open model, 128K context, 140+ languages |
 | **Gemma 3 27B** | 27B | 27B | Yes | Good | Lightweight, 140+ languages |
 | **Gemma 3 4B** | 4B | 4B | Yes | Good | Low-spec machines (8GB RAM) |
 | **K-EXAONE** | 23B (MoE) | 236B | No | Best | Korean-specialized |
@@ -544,7 +548,7 @@ npm run dev      # Watch mode
 | `@opendocuments/cli` | 17 CLI commands (Commander.js) | 3 |
 | `@opendocuments/web` | React SPA with 7 pages (Vite + Tailwind) | -- |
 | `@opendocuments/client` | TypeScript SDK | 3 |
-| 5 model plugins | Ollama, OpenAI, Anthropic, Google, Grok | 41 |
+| 8 model plugins | Ollama, OpenAI, Anthropic, Google, Grok, DeepSeek, Mistral, OpenAI-compatible | 41 |
 | 9 parser plugins | PDF, DOCX, XLSX, HTML, Jupyter, Email, Code, PPTX, Structured | 37 |
 | 8 connector plugins | GitHub, Notion, GDrive, S3, Confluence, Swagger, WebCrawler, WebSearch | 38 |
 

--- a/README.md
+++ b/README.md
@@ -348,9 +348,17 @@ cat README.md | opendocuments ask "Summarize this" --stdin
 opendocuments ask "List endpoints" --json | jq '.sources[].sourcePath'
 
 # Administration
-opendocuments doctor                  # Health check
+opendocuments doctor                  # Health check (per-provider API ping)
 opendocuments auth create-key --name "ci-bot" --role member
 opendocuments export --output ./backup
+
+# Model management
+opendocuments model list --suggestions          # Show installed + curated models
+opendocuments model install-ollama              # One-shot Ollama install (macOS/Linux)
+opendocuments model pull gemma3:27b bge-m3      # Batch pull with disk-space check
+opendocuments model set-key deepseek            # Prompt + save API key to .env
+opendocuments model test                        # Round-trip test against configured LLM
+opendocuments model switch                      # Change provider without editing config
 ```
 
 ### 3. MCP Server

--- a/docs-site/guide/configuration.md
+++ b/docs-site/guide/configuration.md
@@ -12,7 +12,7 @@ export default defineConfig({
   mode: 'personal',        // 'personal' | 'team'
 
   model: {
-    provider: 'ollama',     // 'ollama' | 'openai' | 'anthropic' | 'google' | 'grok'
+    provider: 'ollama',     // 'ollama' | 'openai' | 'anthropic' | 'google' | 'grok' | 'deepseek' | 'mistral' | 'openai-compatible'
     llm: 'qwen2.5:14b',
     embedding: 'bge-m3',
     // embeddingProvider: 'openai',    // Use different provider for embeddings
@@ -74,10 +74,32 @@ export default defineConfig({
 ```typescript
 model: {
   provider: 'ollama',
-  llm: 'qwen2.5:14b',      // Any Ollama model
+  llm: 'qwen2.5:14b',      // Any Ollama model: gemma3, gemma2, llama3.3, qwen2.5, phi4, deepseek-r1...
   embedding: 'bge-m3',
   baseUrl: 'http://localhost:11434',  // Default
 }
+```
+
+Popular Ollama models (April 2026):
+
+```bash
+# Google Gemma 4 (128K context, 140+ languages, multimodal)
+ollama pull gemma3:27b   # Gemma 3 flagship
+ollama pull gemma3:12b   # Balanced
+ollama pull gemma3:4b    # Low-spec
+ollama pull gemma3n      # Selective activation for laptops/phones
+ollama pull gemma4       # Newest release (if available)
+
+# Alibaba Qwen 3.5
+ollama pull qwen2.5:14b
+ollama pull qwen3.5:9b
+
+# Meta Llama 4
+ollama pull llama4:scout
+ollama pull llama4:maverick
+
+# DeepSeek R1 distilled
+ollama pull deepseek-r1:14b
 ```
 
 ### Cloud Models
@@ -107,6 +129,43 @@ model: {
   embedding: 'text-embedding-004',
   apiKey: process.env.GOOGLE_API_KEY,
 }
+
+// DeepSeek (V3.2 / R1 — no embedding, cheapest reasoning)
+model: {
+  provider: 'deepseek',
+  llm: 'deepseek-chat',        // or 'deepseek-reasoner' for R1
+  embedding: 'bge-m3',
+  embeddingProvider: 'ollama',
+  apiKey: process.env.DEEPSEEK_API_KEY,
+}
+
+// Mistral (Small 4 / Large / Codestral / Pixtral)
+model: {
+  provider: 'mistral',
+  llm: 'mistral-small-latest',  // MoE w/ reasoning + vision + code
+  embedding: 'mistral-embed',
+  apiKey: process.env.MISTRAL_API_KEY,
+}
+
+// Generic OpenAI-compatible — works with vLLM, LM Studio, Together, Fireworks, Groq, DeepInfra, SiliconFlow, OpenRouter
+model: {
+  provider: 'openai-compatible',
+  baseUrl: 'https://api.groq.com/openai/v1',  // required
+  llm: 'llama-4-70b-instruct',
+  embedding: 'bge-m3',
+  embeddingProvider: 'ollama',  // Groq has no embeddings
+  apiKey: process.env.GROQ_API_KEY,
+  // extraHeaders: { 'HTTP-Referer': 'https://myapp.com' },  // e.g. for OpenRouter
+}
+
+// Self-hosted vLLM
+model: {
+  provider: 'openai-compatible',
+  baseUrl: 'http://vllm.internal:8000/v1',
+  llm: 'meta-llama/Llama-4-70B-Instruct',
+  embedding: 'BAAI/bge-m3',
+  apiKey: '',  // vLLM accepts empty
+}
 ```
 
 ## Environment Variables
@@ -117,9 +176,15 @@ API keys should be stored in `.env`, never in the config file:
 # .env
 OPENAI_API_KEY=sk-...
 ANTHROPIC_API_KEY=sk-ant-...
+GOOGLE_API_KEY=...
+GROK_API_KEY=xai-...
+DEEPSEEK_API_KEY=sk-...
+MISTRAL_API_KEY=...
+OPENAI_COMPATIBLE_API_KEY=...          # For generic openai-compatible provider
+OPENAI_COMPATIBLE_BASE_URL=https://... # Optional default for openai-compatible baseUrl
 GITHUB_TOKEN=ghp_...
 NOTION_TOKEN=ntn_...
-TAVILY_API_KEY=tvly-...    # For web search integration
+TAVILY_API_KEY=tvly-...                # For web search integration
 ```
 
 The `.env` file is automatically loaded before config resolution.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4327,6 +4327,10 @@
       "resolved": "plugins/model-anthropic",
       "link": true
     },
+    "node_modules/opendocuments-model-deepseek": {
+      "resolved": "plugins/model-deepseek",
+      "link": true
+    },
     "node_modules/opendocuments-model-google": {
       "resolved": "plugins/model-google",
       "link": true
@@ -4335,12 +4339,20 @@
       "resolved": "plugins/model-grok",
       "link": true
     },
+    "node_modules/opendocuments-model-mistral": {
+      "resolved": "plugins/model-mistral",
+      "link": true
+    },
     "node_modules/opendocuments-model-ollama": {
       "resolved": "plugins/model-ollama",
       "link": true
     },
     "node_modules/opendocuments-model-openai": {
       "resolved": "plugins/model-openai",
+      "link": true
+    },
+    "node_modules/opendocuments-model-openai-compatible": {
+      "resolved": "plugins/model-openai-compatible",
       "link": true
     },
     "node_modules/opendocuments-parser-code": {
@@ -6395,7 +6407,7 @@
     },
     "packages/cli": {
       "name": "opendocuments",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.13.0",
@@ -6934,6 +6946,45 @@
         "zod": "^3.23.0"
       }
     },
+    "plugins/model-deepseek": {
+      "name": "opendocuments-model-deepseek",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "opendocuments-core": "0.1.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.5.0",
+        "vitest": "^2.1.0"
+      },
+      "peerDependencies": {
+        "opendocuments-core": "^0.1.0"
+      }
+    },
+    "plugins/model-deepseek/node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "plugins/model-deepseek/node_modules/opendocuments-core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/opendocuments-core/-/opendocuments-core-0.1.0.tgz",
+      "integrity": "sha512-RTWZi443+PnzhTWY0s8liBFZgdr68fWp9e5MtQelZkOF3U7l+wwj1P6ZQhUYlt/3LjABSvNhNFuMdrPYtb2rwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lancedb/lancedb": "^0.27.1",
+        "better-sqlite3": "^11.0.0",
+        "chalk": "^5.3.0",
+        "eventemitter3": "^5.0.0",
+        "jiti": "^2.6.1",
+        "semver": "^7.7.4",
+        "zod": "^3.23.0"
+      }
+    },
     "plugins/model-google": {
       "name": "opendocuments-model-google",
       "version": "0.1.0",
@@ -7004,6 +7055,45 @@
         "zod": "^3.23.0"
       }
     },
+    "plugins/model-mistral": {
+      "name": "opendocuments-model-mistral",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "opendocuments-core": "0.1.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.5.0",
+        "vitest": "^2.1.0"
+      },
+      "peerDependencies": {
+        "opendocuments-core": "^0.1.0"
+      }
+    },
+    "plugins/model-mistral/node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "plugins/model-mistral/node_modules/opendocuments-core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/opendocuments-core/-/opendocuments-core-0.1.0.tgz",
+      "integrity": "sha512-RTWZi443+PnzhTWY0s8liBFZgdr68fWp9e5MtQelZkOF3U7l+wwj1P6ZQhUYlt/3LjABSvNhNFuMdrPYtb2rwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lancedb/lancedb": "^0.27.1",
+        "better-sqlite3": "^11.0.0",
+        "chalk": "^5.3.0",
+        "eventemitter3": "^5.0.0",
+        "jiti": "^2.6.1",
+        "semver": "^7.7.4",
+        "zod": "^3.23.0"
+      }
+    },
     "plugins/model-ollama": {
       "name": "opendocuments-model-ollama",
       "version": "0.1.2",
@@ -7052,6 +7142,45 @@
       },
       "peerDependencies": {
         "opendocuments-core": "^0.1.0"
+      }
+    },
+    "plugins/model-openai-compatible": {
+      "name": "opendocuments-model-openai-compatible",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "opendocuments-core": "0.1.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.5.0",
+        "vitest": "^2.1.0"
+      },
+      "peerDependencies": {
+        "opendocuments-core": "^0.1.0"
+      }
+    },
+    "plugins/model-openai-compatible/node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "plugins/model-openai-compatible/node_modules/opendocuments-core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/opendocuments-core/-/opendocuments-core-0.1.0.tgz",
+      "integrity": "sha512-RTWZi443+PnzhTWY0s8liBFZgdr68fWp9e5MtQelZkOF3U7l+wwj1P6ZQhUYlt/3LjABSvNhNFuMdrPYtb2rwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lancedb/lancedb": "^0.27.1",
+        "better-sqlite3": "^11.0.0",
+        "chalk": "^5.3.0",
+        "eventemitter3": "^5.0.0",
+        "jiti": "^2.6.1",
+        "semver": "^7.7.4",
+        "zod": "^3.23.0"
       }
     },
     "plugins/model-openai/node_modules/jiti": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1070,6 +1070,10 @@
       "resolved": "plugins/connector-confluence",
       "link": true
     },
+    "node_modules/@opendocuments/connector-discord": {
+      "resolved": "plugins/connector-discord",
+      "link": true
+    },
     "node_modules/@opendocuments/connector-gdrive": {
       "resolved": "plugins/connector-gdrive",
       "link": true
@@ -1078,12 +1082,24 @@
       "resolved": "plugins/connector-github",
       "link": true
     },
+    "node_modules/@opendocuments/connector-jira": {
+      "resolved": "plugins/connector-jira",
+      "link": true
+    },
+    "node_modules/@opendocuments/connector-linear": {
+      "resolved": "plugins/connector-linear",
+      "link": true
+    },
     "node_modules/@opendocuments/connector-notion": {
       "resolved": "plugins/connector-notion",
       "link": true
     },
     "node_modules/@opendocuments/connector-s3": {
       "resolved": "plugins/connector-s3",
+      "link": true
+    },
+    "node_modules/@opendocuments/connector-slack": {
+      "resolved": "plugins/connector-slack",
       "link": true
     },
     "node_modules/@opendocuments/connector-swagger": {
@@ -6690,6 +6706,41 @@
         "zod": "^3.23.0"
       }
     },
+    "plugins/connector-discord": {
+      "name": "@opendocuments/connector-discord",
+      "version": "0.1.0",
+      "dependencies": {
+        "opendocuments-core": "0.1.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.5.0",
+        "vitest": "^2.1.0"
+      }
+    },
+    "plugins/connector-discord/node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "plugins/connector-discord/node_modules/opendocuments-core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/opendocuments-core/-/opendocuments-core-0.1.0.tgz",
+      "integrity": "sha512-RTWZi443+PnzhTWY0s8liBFZgdr68fWp9e5MtQelZkOF3U7l+wwj1P6ZQhUYlt/3LjABSvNhNFuMdrPYtb2rwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lancedb/lancedb": "^0.27.1",
+        "better-sqlite3": "^11.0.0",
+        "chalk": "^5.3.0",
+        "eventemitter3": "^5.0.0",
+        "jiti": "^2.6.1",
+        "semver": "^7.7.4",
+        "zod": "^3.23.0"
+      }
+    },
     "plugins/connector-gdrive": {
       "name": "@opendocuments/connector-gdrive",
       "version": "0.1.0",
@@ -6752,6 +6803,76 @@
         "zod": "^3.23.0"
       }
     },
+    "plugins/connector-jira": {
+      "name": "@opendocuments/connector-jira",
+      "version": "0.1.0",
+      "dependencies": {
+        "opendocuments-core": "0.1.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.5.0",
+        "vitest": "^2.1.0"
+      }
+    },
+    "plugins/connector-jira/node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "plugins/connector-jira/node_modules/opendocuments-core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/opendocuments-core/-/opendocuments-core-0.1.0.tgz",
+      "integrity": "sha512-RTWZi443+PnzhTWY0s8liBFZgdr68fWp9e5MtQelZkOF3U7l+wwj1P6ZQhUYlt/3LjABSvNhNFuMdrPYtb2rwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lancedb/lancedb": "^0.27.1",
+        "better-sqlite3": "^11.0.0",
+        "chalk": "^5.3.0",
+        "eventemitter3": "^5.0.0",
+        "jiti": "^2.6.1",
+        "semver": "^7.7.4",
+        "zod": "^3.23.0"
+      }
+    },
+    "plugins/connector-linear": {
+      "name": "@opendocuments/connector-linear",
+      "version": "0.1.0",
+      "dependencies": {
+        "opendocuments-core": "0.1.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.5.0",
+        "vitest": "^2.1.0"
+      }
+    },
+    "plugins/connector-linear/node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "plugins/connector-linear/node_modules/opendocuments-core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/opendocuments-core/-/opendocuments-core-0.1.0.tgz",
+      "integrity": "sha512-RTWZi443+PnzhTWY0s8liBFZgdr68fWp9e5MtQelZkOF3U7l+wwj1P6ZQhUYlt/3LjABSvNhNFuMdrPYtb2rwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lancedb/lancedb": "^0.27.1",
+        "better-sqlite3": "^11.0.0",
+        "chalk": "^5.3.0",
+        "eventemitter3": "^5.0.0",
+        "jiti": "^2.6.1",
+        "semver": "^7.7.4",
+        "zod": "^3.23.0"
+      }
+    },
     "plugins/connector-notion": {
       "name": "@opendocuments/connector-notion",
       "version": "0.1.0",
@@ -6803,6 +6924,44 @@
     },
     "plugins/connector-s3/node_modules/opendocuments-core": {
       "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@lancedb/lancedb": "^0.27.1",
+        "better-sqlite3": "^11.0.0",
+        "chalk": "^5.3.0",
+        "eventemitter3": "^5.0.0",
+        "jiti": "^2.6.1",
+        "semver": "^7.7.4",
+        "zod": "^3.23.0"
+      }
+    },
+    "plugins/connector-slack": {
+      "name": "@opendocuments/connector-slack",
+      "version": "0.1.0",
+      "dependencies": {
+        "opendocuments-core": "^0.1.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.5.0",
+        "vitest": "^2.1.0"
+      },
+      "peerDependencies": {
+        "opendocuments-core": "^0.1.0"
+      }
+    },
+    "plugins/connector-slack/node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "plugins/connector-slack/node_modules/opendocuments-core": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/opendocuments-core/-/opendocuments-core-0.1.2.tgz",
+      "integrity": "sha512-Gty/8VX+Wm81w1NXcXtm91unc6vRRfK7g4O5C0aK4b85vUA5a+bc33GrjP/4Sy3EHfcFn3nB8PW2V1xVDR/NXQ==",
       "license": "MIT",
       "dependencies": {
         "@lancedb/lancedb": "^0.27.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1417,7 +1417,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -2902,6 +2904,21 @@
         "node": ">=6 <7 || >=8"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "license": "MIT",
@@ -3375,6 +3392,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
       }
     },
     "node_modules/js-tokens": {
@@ -6423,7 +6449,7 @@
     },
     "packages/cli": {
       "name": "opendocuments",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.13.0",
@@ -6452,6 +6478,7 @@
     "packages/client": {
       "name": "@opendocuments/client",
       "version": "0.2.0",
+      "license": "MIT",
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
@@ -6459,7 +6486,7 @@
     },
     "packages/core": {
       "name": "opendocuments-core",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@lancedb/lancedb": "^0.27.1",
@@ -6467,6 +6494,7 @@
         "chalk": "^5.3.0",
         "eventemitter3": "^5.0.0",
         "jiti": "^2.6.1",
+        "js-tiktoken": "^1.0.21",
         "semver": "^7.7.4",
         "zod": "^3.23.0"
       },
@@ -6486,7 +6514,7 @@
     },
     "packages/server": {
       "name": "opendocuments-server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.13.0",
@@ -6502,6 +6530,7 @@
     "packages/web": {
       "name": "@opendocuments/web",
       "version": "0.2.0",
+      "license": "MIT",
       "dependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -6677,40 +6706,22 @@
     },
     "plugins/connector-confluence": {
       "name": "@opendocuments/connector-confluence",
-      "version": "0.1.0",
+      "version": "0.1.1",
+      "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
       }
     },
-    "plugins/connector-confluence/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/connector-confluence/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
-      }
-    },
     "plugins/connector-discord": {
       "name": "@opendocuments/connector-discord",
-      "version": "0.1.0",
+      "version": "0.1.1",
+      "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
@@ -6726,752 +6737,300 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "plugins/connector-discord/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/opendocuments-core/-/opendocuments-core-0.1.0.tgz",
-      "integrity": "sha512-RTWZi443+PnzhTWY0s8liBFZgdr68fWp9e5MtQelZkOF3U7l+wwj1P6ZQhUYlt/3LjABSvNhNFuMdrPYtb2rwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
-      }
-    },
     "plugins/connector-gdrive": {
       "name": "@opendocuments/connector-gdrive",
-      "version": "0.1.0",
+      "version": "0.1.1",
+      "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
-      }
-    },
-    "plugins/connector-gdrive/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/connector-gdrive/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
       }
     },
     "plugins/connector-github": {
       "name": "@opendocuments/connector-github",
-      "version": "0.1.0",
+      "version": "0.1.1",
+      "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
-      }
-    },
-    "plugins/connector-github/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/connector-github/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
       }
     },
     "plugins/connector-jira": {
       "name": "@opendocuments/connector-jira",
-      "version": "0.1.0",
+      "version": "0.1.1",
+      "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
-      }
-    },
-    "plugins/connector-jira/node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/connector-jira/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/opendocuments-core/-/opendocuments-core-0.1.0.tgz",
-      "integrity": "sha512-RTWZi443+PnzhTWY0s8liBFZgdr68fWp9e5MtQelZkOF3U7l+wwj1P6ZQhUYlt/3LjABSvNhNFuMdrPYtb2rwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
       }
     },
     "plugins/connector-linear": {
       "name": "@opendocuments/connector-linear",
-      "version": "0.1.0",
+      "version": "0.1.1",
+      "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
-      }
-    },
-    "plugins/connector-linear/node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/connector-linear/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/opendocuments-core/-/opendocuments-core-0.1.0.tgz",
-      "integrity": "sha512-RTWZi443+PnzhTWY0s8liBFZgdr68fWp9e5MtQelZkOF3U7l+wwj1P6ZQhUYlt/3LjABSvNhNFuMdrPYtb2rwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
       }
     },
     "plugins/connector-notion": {
       "name": "@opendocuments/connector-notion",
-      "version": "0.1.0",
+      "version": "0.1.1",
+      "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
-      }
-    },
-    "plugins/connector-notion/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/connector-notion/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
       }
     },
     "plugins/connector-s3": {
       "name": "@opendocuments/connector-s3",
-      "version": "0.1.0",
+      "version": "0.1.1",
+      "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
-      }
-    },
-    "plugins/connector-s3/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/connector-s3/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
       }
     },
     "plugins/connector-slack": {
       "name": "@opendocuments/connector-slack",
-      "version": "0.1.0",
+      "version": "0.1.1",
+      "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "^0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "opendocuments-core": "^0.1.0"
-      }
-    },
-    "plugins/connector-slack/node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/connector-slack/node_modules/opendocuments-core": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/opendocuments-core/-/opendocuments-core-0.1.2.tgz",
-      "integrity": "sha512-Gty/8VX+Wm81w1NXcXtm91unc6vRRfK7g4O5C0aK4b85vUA5a+bc33GrjP/4Sy3EHfcFn3nB8PW2V1xVDR/NXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
+        "opendocuments-core": "^0.3.0"
       }
     },
     "plugins/connector-swagger": {
       "name": "@opendocuments/connector-swagger",
-      "version": "0.1.0",
+      "version": "0.1.1",
+      "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "opendocuments-core": "^0.1.0"
-      }
-    },
-    "plugins/connector-swagger/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/connector-swagger/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
+        "opendocuments-core": "^0.3.0"
       }
     },
     "plugins/connector-web-crawler": {
       "name": "@opendocuments/connector-web-crawler",
-      "version": "0.1.0",
+      "version": "0.1.1",
+      "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0",
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
-      }
-    },
-    "plugins/connector-web-crawler/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/connector-web-crawler/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
       }
     },
     "plugins/connector-web-search": {
       "name": "@opendocuments/connector-web-search",
-      "version": "0.1.0",
+      "version": "0.1.1",
+      "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
-      }
-    },
-    "plugins/connector-web-search/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/connector-web-search/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
       }
     },
     "plugins/model-anthropic": {
       "name": "opendocuments-model-anthropic",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "opendocuments-core": "^0.1.0"
-      }
-    },
-    "plugins/model-anthropic/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/model-anthropic/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
+        "opendocuments-core": "^0.3.0"
       }
     },
     "plugins/model-deepseek": {
-      "name": "opendocuments-model-deepseek",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "opendocuments-core": "^0.1.0"
-      }
-    },
-    "plugins/model-deepseek/node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/model-deepseek/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/opendocuments-core/-/opendocuments-core-0.1.0.tgz",
-      "integrity": "sha512-RTWZi443+PnzhTWY0s8liBFZgdr68fWp9e5MtQelZkOF3U7l+wwj1P6ZQhUYlt/3LjABSvNhNFuMdrPYtb2rwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
+        "opendocuments-core": "^0.3.0"
       }
     },
     "plugins/model-google": {
       "name": "opendocuments-model-google",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "opendocuments-core": "^0.1.0"
-      }
-    },
-    "plugins/model-google/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/model-google/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
+        "opendocuments-core": "^0.3.0"
       }
     },
     "plugins/model-grok": {
       "name": "opendocuments-model-grok",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "opendocuments-core": "^0.1.0"
-      }
-    },
-    "plugins/model-grok/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/model-grok/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
+        "opendocuments-core": "^0.3.0"
       }
     },
     "plugins/model-mistral": {
-      "name": "opendocuments-model-mistral",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "opendocuments-core": "^0.1.0"
-      }
-    },
-    "plugins/model-mistral/node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/model-mistral/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/opendocuments-core/-/opendocuments-core-0.1.0.tgz",
-      "integrity": "sha512-RTWZi443+PnzhTWY0s8liBFZgdr68fWp9e5MtQelZkOF3U7l+wwj1P6ZQhUYlt/3LjABSvNhNFuMdrPYtb2rwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
+        "opendocuments-core": "^0.3.0"
       }
     },
     "plugins/model-ollama": {
       "name": "opendocuments-model-ollama",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "opendocuments-core": "^0.1.0"
-      }
-    },
-    "plugins/model-ollama/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/model-ollama/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
+        "opendocuments-core": "^0.3.0"
       }
     },
     "plugins/model-openai": {
       "name": "opendocuments-model-openai",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "opendocuments-core": "^0.1.0"
+        "opendocuments-core": "^0.3.0"
       }
     },
     "plugins/model-openai-compatible": {
-      "name": "opendocuments-model-openai-compatible",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "opendocuments-core": "^0.1.0"
-      }
-    },
-    "plugins/model-openai-compatible/node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/model-openai-compatible/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/opendocuments-core/-/opendocuments-core-0.1.0.tgz",
-      "integrity": "sha512-RTWZi443+PnzhTWY0s8liBFZgdr68fWp9e5MtQelZkOF3U7l+wwj1P6ZQhUYlt/3LjABSvNhNFuMdrPYtb2rwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
-      }
-    },
-    "plugins/model-openai/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/model-openai/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
+        "opendocuments-core": "^0.3.0"
       }
     },
     "plugins/parser-code": {
       "name": "opendocuments-parser-code",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "opendocuments-core": "^0.1.0"
-      }
-    },
-    "plugins/parser-code/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/parser-code/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
+        "opendocuments-core": "^0.3.0"
       }
     },
     "plugins/parser-docx": {
       "name": "opendocuments-parser-docx",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "mammoth": "^1.8.0",
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "opendocuments-core": "^0.1.0"
-      }
-    },
-    "plugins/parser-docx/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/parser-docx/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
+        "opendocuments-core": "^0.3.0"
       }
     },
     "plugins/parser-email": {
       "name": "opendocuments-parser-email",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
       }
     },
-    "plugins/parser-email/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/parser-email/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
-      }
-    },
     "plugins/parser-html": {
       "name": "opendocuments-parser-html",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0",
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "@types/cheerio": "^0.22.35",
@@ -7479,70 +7038,30 @@
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "opendocuments-core": "^0.1.0"
-      }
-    },
-    "plugins/parser-html/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/parser-html/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
+        "opendocuments-core": "^0.3.0"
       }
     },
     "plugins/parser-jupyter": {
       "name": "opendocuments-parser-jupyter",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "opendocuments-core": "^0.1.0"
-      }
-    },
-    "plugins/parser-jupyter/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/parser-jupyter/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
+        "opendocuments-core": "^0.3.0"
       }
     },
     "plugins/parser-pdf": {
       "name": "opendocuments-parser-pdf",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0",
+        "opendocuments-core": "0.3.0",
         "pdf-parse": "^1.1.1"
       },
       "devDependencies": {
@@ -7551,70 +7070,31 @@
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "opendocuments-core": "^0.1.0"
-      }
-    },
-    "plugins/parser-pdf/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/parser-pdf/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
+        "opendocuments-core": "^0.3.0"
       }
     },
     "plugins/parser-pptx": {
       "name": "opendocuments-parser-pptx",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0"
+        "jszip": "^3.10.1",
+        "opendocuments-core": "0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "opendocuments-core": "^0.1.0"
-      }
-    },
-    "plugins/parser-pptx/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/parser-pptx/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
+        "opendocuments-core": "^0.3.0"
       }
     },
     "plugins/parser-xlsx": {
       "name": "opendocuments-parser-xlsx",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "opendocuments-core": "0.1.0",
+        "opendocuments-core": "0.3.0",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -7622,27 +7102,7 @@
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "opendocuments-core": "^0.1.0"
-      }
-    },
-    "plugins/parser-xlsx/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "plugins/parser-xlsx/node_modules/opendocuments-core": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@lancedb/lancedb": "^0.27.1",
-        "better-sqlite3": "^11.0.0",
-        "chalk": "^5.3.0",
-        "eventemitter3": "^5.0.0",
-        "jiti": "^2.6.1",
-        "semver": "^7.7.4",
-        "zod": "^3.23.0"
+        "opendocuments-core": "^0.3.0"
       }
     }
   }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -2,6 +2,92 @@ import { Command } from 'commander'
 import { log } from 'opendocuments-core'
 import { getContext, shutdownContext } from '../utils/bootstrap.js'
 
+/**
+ * Provider-specific diagnostic endpoints. Each entry is a GET that returns 200
+ * when the API key is valid and reachable.
+ */
+const PROVIDER_DIAGNOSTICS: Record<string, {
+  url: string | ((cfg: { baseUrl?: string; apiKey?: string }) => string)
+  headers: (key: string) => Record<string, string>
+  envVar: string
+  docs: string
+}> = {
+  openai: {
+    url: 'https://api.openai.com/v1/models',
+    headers: (k) => ({ Authorization: `Bearer ${k}` }),
+    envVar: 'OPENAI_API_KEY',
+    docs: 'https://platform.openai.com/api-keys',
+  },
+  anthropic: {
+    url: 'https://api.anthropic.com/v1/models',
+    headers: (k) => ({ 'x-api-key': k, 'anthropic-version': '2023-06-01' }),
+    envVar: 'ANTHROPIC_API_KEY',
+    docs: 'https://console.anthropic.com/settings/keys',
+  },
+  google: {
+    url: (cfg) => `https://generativelanguage.googleapis.com/v1beta/models?key=${cfg.apiKey ?? ''}`,
+    headers: () => ({}),
+    envVar: 'GOOGLE_API_KEY',
+    docs: 'https://aistudio.google.com/apikey',
+  },
+  grok: {
+    url: 'https://api.x.ai/v1/models',
+    headers: (k) => ({ Authorization: `Bearer ${k}` }),
+    envVar: 'XAI_API_KEY',
+    docs: 'https://console.x.ai',
+  },
+  deepseek: {
+    url: 'https://api.deepseek.com/v1/models',
+    headers: (k) => ({ Authorization: `Bearer ${k}` }),
+    envVar: 'DEEPSEEK_API_KEY',
+    docs: 'https://platform.deepseek.com/api_keys',
+  },
+  mistral: {
+    url: 'https://api.mistral.ai/v1/models',
+    headers: (k) => ({ Authorization: `Bearer ${k}` }),
+    envVar: 'MISTRAL_API_KEY',
+    docs: 'https://console.mistral.ai/api-keys',
+  },
+  'openai-compatible': {
+    url: (cfg) => `${cfg.baseUrl?.replace(/\/+$/, '')}/models`,
+    headers: (k) => {
+      const h: Record<string, string> = {}
+      if (k) h.Authorization = `Bearer ${k}`
+      return h
+    },
+    envVar: 'OPENAI_COMPATIBLE_API_KEY',
+    docs: '(configured endpoint)',
+  },
+}
+
+async function pingProvider(
+  provider: string,
+  cfg: { baseUrl?: string; apiKey?: string },
+): Promise<{ ok: boolean; status?: number; message: string }> {
+  const diag = PROVIDER_DIAGNOSTICS[provider]
+  if (!diag) return { ok: false, message: `no diagnostic for provider '${provider}'` }
+  const apiKey = cfg.apiKey ?? process.env[diag.envVar] ?? ''
+  if (!apiKey && provider !== 'openai-compatible') {
+    return { ok: false, message: `${diag.envVar} not set  (get a key: ${diag.docs})` }
+  }
+  const url = typeof diag.url === 'function' ? diag.url({ ...cfg, apiKey }) : diag.url
+  if (!url || url.startsWith('undefined')) {
+    return { ok: false, message: 'baseUrl is not set (openai-compatible requires it)' }
+  }
+  try {
+    const res = await fetch(url, { headers: diag.headers(apiKey), signal: AbortSignal.timeout(10000) })
+    if (res.status === 401 || res.status === 403) {
+      return { ok: false, status: res.status, message: `invalid API key (HTTP ${res.status})` }
+    }
+    if (!res.ok) {
+      return { ok: false, status: res.status, message: `HTTP ${res.status}` }
+    }
+    return { ok: true, status: res.status, message: 'API reachable, key accepted' }
+  } catch (err) {
+    return { ok: false, message: (err as Error).message }
+  }
+}
+
 export function doctorCommand() {
   return new Command('doctor')
     .description('Run health diagnostics')
@@ -68,8 +154,41 @@ export function doctorCommand() {
           }
         }
 
-        // Ollama-specific diagnostics
-        if (ctx.config.model.provider === 'ollama') {
+        // Provider-specific diagnostics (non-Ollama cloud/self-hosted)
+        const provider = ctx.config.model.provider
+        if (provider !== 'ollama' && PROVIDER_DIAGNOSTICS[provider]) {
+          log.blank()
+          log.heading(`${provider} Diagnostics`)
+          const result = await pingProvider(provider, {
+            apiKey: ctx.config.model.apiKey,
+            baseUrl: ctx.config.model.baseUrl,
+          })
+          if (result.ok) {
+            log.ok(`${provider.padEnd(15)} ${result.message}`)
+          } else {
+            log.fail(`${provider.padEnd(15)} ${result.message}`)
+            hasIssues = true
+          }
+
+          // Also check secondary embedding provider if different
+          const embProvider = ctx.config.model.embeddingProvider
+          if (embProvider && embProvider !== provider && PROVIDER_DIAGNOSTICS[embProvider]) {
+            const embResult = await pingProvider(embProvider, {
+              apiKey: ctx.config.model.embeddingApiKey,
+              baseUrl: ctx.config.model.baseUrl,
+            })
+            if (embResult.ok) {
+              log.ok(`${embProvider.padEnd(15)} ${embResult.message}  (embedding)`)
+            } else {
+              log.fail(`${embProvider.padEnd(15)} ${embResult.message}  (embedding)`)
+              hasIssues = true
+            }
+          }
+        }
+
+        // Ollama-specific diagnostics (primary provider OR secondary embedder)
+        const usesOllama = provider === 'ollama' || ctx.config.model.embeddingProvider === 'ollama'
+        if (usesOllama) {
           log.blank()
           log.heading('Ollama Diagnostics')
 
@@ -102,9 +221,15 @@ export function doctorCommand() {
           }
 
           if (ollamaReachable) {
-            const requiredModels = Array.from(
-              new Set([ctx.config.model.llm, ctx.config.model.embedding])
-            )
+            // Only check models that Ollama is actually responsible for.
+            const ollamaModels: string[] = []
+            if (ctx.config.model.provider === 'ollama') {
+              ollamaModels.push(ctx.config.model.llm)
+            }
+            if (ctx.config.model.provider === 'ollama' || ctx.config.model.embeddingProvider === 'ollama') {
+              ollamaModels.push(ctx.config.model.embedding)
+            }
+            const requiredModels = Array.from(new Set(ollamaModels))
 
             for (const required of requiredModels) {
               // Ollama tags may include ":latest" suffix; match on base name or exact name

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -4,34 +4,54 @@ import chalk from 'chalk'
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { cpus, totalmem, platform, arch } from 'node:os'
+import {
+  estimateModelSize,
+  formatBytes,
+  getAvailableDiskBytes,
+  getOllamaInstallCommand,
+  isOllamaRunning,
+  listOllamaModels,
+  pullOllamaModel as pullOllamaModelWithProgress,
+} from '../utils/ollama.js'
 
 async function checkOllamaRunning(): Promise<boolean> {
-  try {
-    const res = await fetch('http://localhost:11434/api/tags', { signal: AbortSignal.timeout(3000) })
-    return res.ok
-  } catch {
-    return false
-  }
+  return isOllamaRunning()
 }
 
-async function getOllamaModels(): Promise<string[]> {
-  try {
-    const res = await fetch('http://localhost:11434/api/tags', { signal: AbortSignal.timeout(3000) })
-    if (!res.ok) return []
-    const data = await res.json() as { models?: Array<{ name: string }> }
-    return (data.models || []).map(m => m.name)
-  } catch {
-    return []
-  }
+async function getOllamaModelNames(): Promise<string[]> {
+  return (await listOllamaModels()).map((m) => m.name)
 }
 
 async function pullOllamaModel(model: string): Promise<boolean> {
+  let lastLine = ''
+  const ok = await pullOllamaModelWithProgress(model, 'http://localhost:11434', (line) => {
+    if (line !== lastLine) {
+      lastLine = line
+      process.stdout.write(`\r\x1b[K  ${line}`)
+    }
+  })
+  process.stdout.write('\n')
+  return ok
+}
+
+async function tryInstallOllama(): Promise<boolean> {
+  const install = getOllamaInstallCommand()
+  if (!install.supported) {
+    log.info(`Automatic install is not supported on this platform. Download from: ${install.url}`)
+    return false
+  }
+  const { confirm } = await import('@inquirer/prompts')
+  log.blank()
+  log.info('Ollama is not installed. The official install script is:')
+  log.dim(`  ${install.command}`)
+  const go = await confirm({ message: 'Run the official Ollama install script now?', default: false })
+  if (!go) return false
   const { execSync } = await import('node:child_process')
   try {
-    console.log(`  Pulling ${model}... (this may take a few minutes)`)
-    execSync(`ollama pull ${model}`, { stdio: 'inherit', timeout: 600000 })
+    execSync(install.command!, { stdio: 'inherit' })
     return true
-  } catch {
+  } catch (err) {
+    log.fail(`Install failed: ${(err as Error).message}`)
     return false
   }
 }
@@ -50,6 +70,18 @@ async function validateCloudApiKey(provider: string, apiKey: string): Promise<bo
     google: {
       url: `https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey}`,
       headers: {},
+    },
+    grok: {
+      url: 'https://api.x.ai/v1/models',
+      headers: { 'Authorization': `Bearer ${apiKey}` },
+    },
+    deepseek: {
+      url: 'https://api.deepseek.com/v1/models',
+      headers: { 'Authorization': `Bearer ${apiKey}` },
+    },
+    mistral: {
+      url: 'https://api.mistral.ai/v1/models',
+      headers: { 'Authorization': `Bearer ${apiKey}` },
     },
   }
   const endpoint = endpoints[provider]
@@ -104,26 +136,49 @@ export function initCommand() {
         message: 'Model backend:',
         choices: [
           { name: `Local (Ollama) ${chalk.dim('-- data stays on your machine')}`, value: 'ollama' },
-          { name: `Cloud ${chalk.dim('-- OpenAI, Anthropic, Google, Grok')}`, value: 'cloud' },
+          { name: `Cloud ${chalk.dim('-- OpenAI, Anthropic, Google, Grok, DeepSeek, Mistral')}`, value: 'cloud' },
+          { name: `OpenAI-compatible endpoint ${chalk.dim('-- vLLM / LM Studio / Groq / Together / Fireworks / OpenRouter')}`, value: 'openai-compatible' },
         ],
       })
 
       let provider = 'ollama'
       let apiKey = ''
+      let baseUrl = ''
       let embeddingProvider: string | undefined
       let embeddingApiKey: string | undefined
       let llmModel = 'qwen2.5:14b'
       let embeddingModel = 'bge-m3'
 
-      if (backend === 'cloud') {
+      if (backend === 'openai-compatible') {
+        provider = 'openai-compatible'
+        baseUrl = await input({
+          message: 'Base URL (include /v1 path):',
+          default: 'https://api.groq.com/openai/v1',
+        })
+        apiKey = await input({ message: 'API key (leave empty for local vLLM/LM Studio):', default: '' })
+        llmModel = await input({ message: 'LLM model id:', default: 'llama-4-70b-instruct' })
+        const wantEmbed = await confirm({
+          message: 'Does this endpoint provide embeddings?',
+          default: false,
+        })
+        if (wantEmbed) {
+          embeddingModel = await input({ message: 'Embedding model id:', default: 'bge-m3' })
+        } else {
+          log.info('Using local Ollama BGE-M3 as secondary embedding provider.')
+          embeddingProvider = 'ollama'
+          embeddingModel = 'bge-m3'
+        }
+      } else if (backend === 'cloud') {
         // 5. Cloud provider
         provider = await select({
           message: 'Cloud provider:',
           choices: [
-            { name: 'OpenAI (GPT-4o)', value: 'openai' },
-            { name: 'Anthropic (Claude)', value: 'anthropic' },
-            { name: 'Google (Gemini)', value: 'google' },
-            { name: 'Grok (xAI)', value: 'grok' },
+            { name: 'OpenAI (GPT-4o / GPT-5.4)', value: 'openai' },
+            { name: 'Anthropic (Claude Sonnet 4)', value: 'anthropic' },
+            { name: 'Google (Gemini 2.5 Flash)', value: 'google' },
+            { name: 'Grok (xAI Grok 4)', value: 'grok' },
+            { name: `DeepSeek ${chalk.dim('(V3.2 / R1 — cheap reasoning, 164K ctx)')}`, value: 'deepseek' },
+            { name: `Mistral ${chalk.dim('(Small 4 MoE — reasoning + vision + code)')}`, value: 'mistral' },
           ],
         })
 
@@ -133,6 +188,8 @@ export function initCommand() {
           anthropic: 'ANTHROPIC_API_KEY',
           google: 'GOOGLE_API_KEY',
           grok: 'XAI_API_KEY',
+          deepseek: 'DEEPSEEK_API_KEY',
+          mistral: 'MISTRAL_API_KEY',
         }
 
         apiKey = await input({
@@ -156,17 +213,19 @@ export function initCommand() {
         }
 
         // Set defaults based on provider
-        const providerDefaults: Record<string, { llm: string; embedding: string }> = {
+        const providerDefaults: Record<string, { llm: string; embedding: string; needsSecondaryEmbedding?: boolean }> = {
           openai: { llm: 'gpt-4o', embedding: 'text-embedding-3-small' },
-          anthropic: { llm: 'claude-sonnet-4-20250514', embedding: 'bge-m3' }, // Anthropic has no embedding
+          anthropic: { llm: 'claude-sonnet-4-20250514', embedding: 'bge-m3', needsSecondaryEmbedding: true },
           google: { llm: 'gemini-2.5-flash', embedding: 'text-embedding-004' },
-          grok: { llm: 'grok-3', embedding: 'grok-2-embed' },
+          grok: { llm: 'grok-4', embedding: 'grok-2-embed' },
+          deepseek: { llm: 'deepseek-chat', embedding: 'bge-m3', needsSecondaryEmbedding: true },
+          mistral: { llm: 'mistral-small-latest', embedding: 'mistral-embed' },
         }
         llmModel = providerDefaults[provider].llm
         embeddingModel = providerDefaults[provider].embedding
 
-        if (provider === 'anthropic') {
-          log.wait('Anthropic does not provide an embedding API.')
+        if (providerDefaults[provider].needsSecondaryEmbedding) {
+          log.wait(`${provider} does not provide an embedding API — choose a secondary embedding provider.`)
           const embeddingChoice = await select({
             message: 'Embedding provider:',
             choices: [
@@ -187,25 +246,31 @@ export function initCommand() {
           log.info(`Embedding will use ${embeddingChoice === 'ollama' ? 'Ollama BGE-M3' : 'OpenAI text-embedding-3-small'}`)
         }
       } else {
-        // Local model recommendation
+        // Local model recommendation (April 2026)
         log.blank()
         log.info('Recommended models for your system:')
 
         if (specs.ramGB >= 32) {
-          log.arrow(`${chalk.cyan('*')} Qwen 2.5 14B ${chalk.dim('(recommended -- Vision, Korean support)')}`)
-          log.dim('    Llama 3.3 8B (lightweight)')
-          log.dim('    EXAONE 7.8B (Korean specialized)')
+          log.arrow(`${chalk.cyan('*')} Gemma 3 27B ${chalk.dim('(recommended -- 128K ctx, multilingual, multimodal)')}`)
+          log.dim('    Qwen 3.5 27B (flagship Korean)')
+          log.dim('    Llama 4 Scout (10M context, MoE)')
+          log.dim('    DeepSeek R1 14B (reasoning, distilled)')
         } else if (specs.ramGB >= 16) {
-          log.arrow(`${chalk.cyan('*')} Qwen 2.5 7B ${chalk.dim('(recommended for 16GB RAM)')}`)
+          log.arrow(`${chalk.cyan('*')} Gemma 3 12B ${chalk.dim('(recommended for 16GB RAM)')}`)
+          log.dim('    Qwen 3.5 9B (Korean excellent)')
           log.dim('    Gemma 3 4B (lightweight)')
         } else {
           log.arrow(`${chalk.cyan('*')} Gemma 3 4B ${chalk.dim('(recommended for limited RAM)')}`)
-          log.info('Limited RAM detected. Consider a cloud provider for better performance.')
+          log.dim('    Gemma 3n (selective activation, laptop/phone)')
+          log.info('Limited RAM detected. A cloud provider (DeepSeek is cheapest) may give better results.')
         }
 
         llmModel = await input({
           message: 'LLM model:',
-          default: specs.ramGB >= 32 ? 'qwen2.5:14b' : specs.ramGB >= 16 ? 'qwen2.5:7b' : 'gemma3:4b',
+          default:
+            specs.ramGB >= 32 ? 'gemma3:27b' :
+            specs.ramGB >= 16 ? 'gemma3:12b' :
+                                'gemma3:4b',
         })
 
         embeddingModel = await input({
@@ -247,6 +312,7 @@ export function initCommand() {
         mode: mode as 'personal' | 'team',
         provider,
         apiKey,
+        baseUrl,
         embeddingProvider,
         embeddingApiKey,
         llmModel,
@@ -307,28 +373,64 @@ export function initCommand() {
       log.dim(`  Preset     ${preset}`)
       log.blank()
       log.heading('Next Steps')
-      if (backend === 'ollama') {
+      // Ollama flow triggers both when backend=='ollama' AND when cloud provider
+      // needs a secondary Ollama embedder.
+      const needsOllama = backend === 'ollama' || embeddingProvider === 'ollama'
+      if (needsOllama) {
         log.blank()
         log.wait('Checking Ollama availability...')
-        const ollamaRunning = await checkOllamaRunning()
+        let ollamaRunning = await checkOllamaRunning()
+        if (!ollamaRunning) {
+          // Try to auto-install
+          const installed = await tryInstallOllama()
+          if (installed) {
+            log.ok('Ollama installed')
+            log.wait('Waiting for Ollama daemon to come up...')
+            for (let i = 0; i < 10; i++) {
+              await new Promise((r) => setTimeout(r, 1500))
+              if (await checkOllamaRunning()) { ollamaRunning = true; break }
+            }
+          }
+        }
+
         if (ollamaRunning) {
           log.ok('Ollama is running')
-          const models = await getOllamaModels()
+          const models = await getOllamaModelNames()
           const needsPull: string[] = []
-          for (const model of [llmModel, embeddingModel]) {
-            if (models.some(m => m.startsWith(model.split(':')[0]))) {
+          const modelsToCheck = backend === 'ollama' ? [llmModel, embeddingModel] : [embeddingModel]
+          for (const model of modelsToCheck) {
+            if (models.some(m => m === model || m === `${model}:latest` || m.startsWith(`${model}:`))) {
               log.ok(`Model ${model} is available`)
             } else {
               needsPull.push(model)
             }
           }
           if (needsPull.length > 0) {
+            // Disk space pre-check
+            const available = getAvailableDiskBytes()
+            let totalEstimate = 0
+            const sizeLines: string[] = []
+            for (const m of needsPull) {
+              const est = estimateModelSize(m)
+              if (est) { totalEstimate += est; sizeLines.push(`  ${m.padEnd(24)} ~${formatBytes(est)}`) }
+            }
+            if (sizeLines.length > 0) {
+              log.info('Estimated disk footprint:')
+              for (const l of sizeLines) console.log(l)
+              if (available !== null) {
+                log.info(`Available disk: ${formatBytes(available)}`)
+                if (available < totalEstimate + 1.5e9) {
+                  log.fail(`Warning: disk may be too low (need ~${formatBytes(totalEstimate + 1.5e9)}).`)
+                }
+              }
+            }
             const autoPull = await confirm({
               message: `Pull missing models (${needsPull.join(', ')})?`,
               default: true,
             })
             if (autoPull) {
               for (const model of needsPull) {
+                log.wait(`Pulling ${model}...`)
                 const success = await pullOllamaModel(model)
                 if (success) {
                   log.ok(`${model} pulled successfully`)
@@ -341,13 +443,18 @@ export function initCommand() {
             }
           }
         } else {
-          log.fail('Ollama is not running or not installed')
-          log.arrow('Install Ollama: https://ollama.com')
-          log.arrow('Then start it:  ollama serve')
-          log.arrow(`Then pull models: ollama pull ${llmModel} && ollama pull ${embeddingModel}`)
+          log.fail('Ollama is still not reachable')
+          const install = getOllamaInstallCommand()
+          if (install.supported) {
+            log.arrow(`Install:  ${install.command}`)
+          } else {
+            log.arrow(`Download: ${install.url}`)
+          }
+          log.arrow('Then start: ollama serve')
+          log.arrow(`Then pull:  ollama pull ${llmModel} && ollama pull ${embeddingModel}`)
         }
       }
-      if (backend === 'cloud' && !apiKey) {
+      if ((backend === 'cloud' || backend === 'openai-compatible') && !apiKey) {
         const envVarName = getEnvVarName(provider)
         log.arrow(`Set API key: export ${envVarName}=your-key-here`)
       }
@@ -387,6 +494,7 @@ interface ConfigOptions {
   mode: 'personal' | 'team'
   provider: string
   apiKey: string
+  baseUrl?: string
   embeddingProvider?: string
   embeddingApiKey?: string
   llmModel: string
@@ -413,7 +521,11 @@ function generateConfigFile(opts: ConfigOptions): string {
     lines.push(`    embeddingProvider: '${opts.embeddingProvider}',`)
   }
 
-  if (opts.apiKey) {
+  if (opts.baseUrl) {
+    lines.push(`    baseUrl: '${opts.baseUrl}',`)
+  }
+
+  if (opts.apiKey || opts.provider === 'openai-compatible') {
     lines.push(`    apiKey: process.env.${getEnvVarName(opts.provider)},`)
   }
 
@@ -461,6 +573,9 @@ function getEnvVarName(provider: string): string {
     anthropic: 'ANTHROPIC_API_KEY',
     google: 'GOOGLE_API_KEY',
     grok: 'XAI_API_KEY',
+    deepseek: 'DEEPSEEK_API_KEY',
+    mistral: 'MISTRAL_API_KEY',
+    'openai-compatible': 'OPENAI_COMPATIBLE_API_KEY',
     ollama: 'OLLAMA_URL',
   }
   return map[provider] || 'API_KEY'

--- a/packages/cli/src/commands/model.ts
+++ b/packages/cli/src/commands/model.ts
@@ -1,0 +1,369 @@
+import { Command } from 'commander'
+import { log, loadConfig } from 'opendocuments-core'
+import chalk from 'chalk'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  deleteOllamaModel,
+  estimateModelSize,
+  formatBytes,
+  getAvailableDiskBytes,
+  getOllamaInstallCommand,
+  isOllamaRunning,
+  listOllamaModels,
+  pullOllamaModel,
+} from '../utils/ollama.js'
+
+/* ------------------------------------------------------------------ */
+/*  Curated suggestion catalog (April 2026)                           */
+/* ------------------------------------------------------------------ */
+
+interface Suggestion {
+  tag: string
+  description: string
+  size: string
+  provider: 'ollama' | 'cloud'
+}
+
+const LOCAL_SUGGESTIONS: Suggestion[] = [
+  // Google Gemma family
+  { tag: 'gemma3:27b', description: 'Google Gemma 3 27B — 128K ctx, multimodal, 140+ languages', size: '~17GB', provider: 'ollama' },
+  { tag: 'gemma3:12b', description: 'Gemma 3 12B — balanced, 128K ctx', size: '~7.5GB', provider: 'ollama' },
+  { tag: 'gemma3:4b', description: 'Gemma 3 4B — low-spec friendly', size: '~2.5GB', provider: 'ollama' },
+  { tag: 'gemma3n', description: 'Gemma 3n — selective activation for laptops/phones', size: '~2.8GB', provider: 'ollama' },
+  // Qwen
+  { tag: 'qwen2.5:14b', description: 'Qwen 2.5 14B — vision + Korean (legacy default)', size: '~9GB', provider: 'ollama' },
+  { tag: 'qwen3.5:9b', description: 'Qwen 3.5 9B — general, Korean excellent', size: '~5.5GB', provider: 'ollama' },
+  { tag: 'qwen3.5:27b', description: 'Qwen 3.5 27B — flagship local model', size: '~17GB', provider: 'ollama' },
+  // Meta Llama
+  { tag: 'llama4:scout', description: 'Llama 4 Scout — 10M context, MoE', size: '~65GB', provider: 'ollama' },
+  { tag: 'llama4:maverick', description: 'Llama 4 Maverick — top open-source quality', size: '~230GB', provider: 'ollama' },
+  // DeepSeek (distilled for local)
+  { tag: 'deepseek-r1:14b', description: 'DeepSeek R1 distilled 14B — reasoning', size: '~9GB', provider: 'ollama' },
+  // Embeddings
+  { tag: 'bge-m3', description: 'BGE-M3 — best open embedding, 1024-dim', size: '~1.2GB', provider: 'ollama' },
+  { tag: 'nomic-embed-text', description: 'nomic-embed-text — lightweight 768-dim', size: '~300MB', provider: 'ollama' },
+]
+
+const CLOUD_SUGGESTIONS: Suggestion[] = [
+  { tag: 'openai:gpt-4o', description: 'OpenAI GPT-4o — general purpose, vision', size: 'API', provider: 'cloud' },
+  { tag: 'anthropic:claude-sonnet-4-20250514', description: 'Claude Sonnet 4 — long context, coding', size: 'API', provider: 'cloud' },
+  { tag: 'google:gemini-2.5-flash', description: 'Gemini 2.5 Flash — multimodal', size: 'API', provider: 'cloud' },
+  { tag: 'deepseek:deepseek-chat', description: 'DeepSeek V3.2 — $0.26/Mtok, 164K ctx', size: 'API', provider: 'cloud' },
+  { tag: 'deepseek:deepseek-reasoner', description: 'DeepSeek R1 — reasoning specialist', size: 'API', provider: 'cloud' },
+  { tag: 'mistral:mistral-small-latest', description: 'Mistral Small 4 — MoE w/ reasoning + vision + code', size: 'API', provider: 'cloud' },
+  { tag: 'mistral:mistral-large-latest', description: 'Mistral Large 2.1 — flagship reasoning', size: 'API', provider: 'cloud' },
+  { tag: 'grok:grok-4', description: 'xAI Grok 4 — real-time knowledge', size: 'API', provider: 'cloud' },
+]
+
+/* ------------------------------------------------------------------ */
+/*  Command                                                           */
+/* ------------------------------------------------------------------ */
+
+export function modelCommand() {
+  const cmd = new Command('model').description('Manage LLM / embedding models')
+
+  // ---------- list ----------
+  cmd.command('list')
+    .alias('ls')
+    .description('Show configured + locally installed models and suggestions')
+    .option('--suggestions', 'Also print curated model suggestions')
+    .action(async (opts) => {
+      const config = loadConfig(process.cwd())
+      const baseUrl = config.model.baseUrl || 'http://localhost:11434'
+
+      log.heading('Current configuration')
+      log.dim(`  provider          ${config.model.provider}`)
+      log.dim(`  llm               ${config.model.llm}`)
+      log.dim(`  embedding         ${config.model.embedding}`)
+      if (config.model.embeddingProvider) {
+        log.dim(`  embeddingProvider ${config.model.embeddingProvider}`)
+      }
+      if (config.model.baseUrl) {
+        log.dim(`  baseUrl           ${config.model.baseUrl}`)
+      }
+      log.blank()
+
+      if (config.model.provider === 'ollama' || config.model.embeddingProvider === 'ollama') {
+        log.heading(`Installed Ollama models @ ${baseUrl}`)
+        const reachable = await isOllamaRunning(baseUrl)
+        if (!reachable) {
+          log.fail(`Ollama not reachable at ${baseUrl}`)
+          log.arrow('Start Ollama with: ollama serve')
+        } else {
+          const models = await listOllamaModels(baseUrl)
+          if (models.length === 0) {
+            log.info('No local models installed.')
+            log.arrow(`Pull one:  opendocuments model pull ${config.model.llm}`)
+          } else {
+            for (const m of models) {
+              const params = m.details?.parameter_size ?? ''
+              const quant = m.details?.quantization_level ?? ''
+              const tag = params || quant ? chalk.dim(`  (${[params, quant].filter(Boolean).join(', ')})`) : ''
+              console.log(`  ${chalk.cyan(m.name.padEnd(32))} ${formatBytes(m.size).padStart(8)}${tag}`)
+            }
+          }
+        }
+        log.blank()
+      }
+
+      if (opts.suggestions) {
+        log.heading('Suggested local models (ollama pull)')
+        for (const s of LOCAL_SUGGESTIONS) {
+          console.log(`  ${chalk.cyan(s.tag.padEnd(32))} ${s.size.padStart(8)}  ${chalk.dim(s.description)}`)
+        }
+        log.blank()
+        log.heading('Suggested cloud providers')
+        for (const s of CLOUD_SUGGESTIONS) {
+          console.log(`  ${chalk.cyan(s.tag.padEnd(48))} ${chalk.dim(s.description)}`)
+        }
+        log.blank()
+        log.arrow('See all: https://ollama.com/library')
+      } else {
+        log.arrow('Run with --suggestions to see popular models you can install')
+      }
+    })
+
+  // ---------- pull ----------
+  cmd.command('pull <name>')
+    .description('Pull an Ollama model (checks disk space, shows progress)')
+    .option('--base-url <url>', 'Ollama base URL', 'http://localhost:11434')
+    .option('--yes', 'Skip disk space confirmation')
+    .action(async (name: string, opts: { baseUrl: string; yes?: boolean }) => {
+      const reachable = await isOllamaRunning(opts.baseUrl)
+      if (!reachable) {
+        log.fail(`Ollama not reachable at ${opts.baseUrl}`)
+        const install = getOllamaInstallCommand()
+        if (install.supported) {
+          log.arrow(`Install:  ${install.command}`)
+        } else {
+          log.arrow(`Download:  ${install.url}`)
+        }
+        log.arrow('Then:     ollama serve')
+        process.exitCode = 1
+        return
+      }
+
+      // Disk space pre-check
+      const estimate = estimateModelSize(name)
+      const available = getAvailableDiskBytes()
+      if (estimate && available !== null) {
+        const margin = 1.5e9 // keep 1.5GB headroom
+        log.info(`Estimated size:  ~${formatBytes(estimate)}`)
+        log.info(`Available disk:  ${formatBytes(available)}`)
+        if (available < estimate + margin) {
+          log.fail(
+            `Not enough free disk space (need ~${formatBytes(estimate + margin)}, have ${formatBytes(available)}).`,
+          )
+          if (!opts.yes) {
+            const { confirm } = await import('@inquirer/prompts')
+            const proceed = await confirm({ message: 'Pull anyway?', default: false })
+            if (!proceed) return
+          }
+        }
+      } else if (estimate) {
+        log.info(`Estimated size: ~${formatBytes(estimate)} (disk-free lookup unavailable)`)
+      }
+
+      log.wait(`Pulling ${chalk.cyan(name)} ...`)
+      let lastPrinted = ''
+      const ok = await pullOllamaModel(name, opts.baseUrl, (line) => {
+        if (line !== lastPrinted) {
+          lastPrinted = line
+          process.stdout.write(`\r\x1b[K  ${line}`)
+        }
+      })
+      process.stdout.write('\n')
+
+      if (ok) {
+        log.ok(`Pulled ${name}`)
+      } else {
+        log.fail(`Failed to pull ${name}`)
+        log.arrow(`Try manually:  ollama pull ${name}`)
+        process.exitCode = 1
+      }
+    })
+
+  // ---------- rm ----------
+  cmd.command('rm <name>')
+    .alias('remove')
+    .description('Delete an Ollama model')
+    .option('--base-url <url>', 'Ollama base URL', 'http://localhost:11434')
+    .option('--yes', 'Skip confirmation')
+    .action(async (name: string, opts: { baseUrl: string; yes?: boolean }) => {
+      if (!opts.yes) {
+        const { confirm } = await import('@inquirer/prompts')
+        const yes = await confirm({ message: `Delete local model ${name}?`, default: false })
+        if (!yes) return
+      }
+      const ok = await deleteOllamaModel(name, opts.baseUrl)
+      if (ok) log.ok(`Removed ${name}`)
+      else {
+        log.fail(`Failed to remove ${name}`)
+        process.exitCode = 1
+      }
+    })
+
+  // ---------- test ----------
+  cmd.command('test')
+    .description('Run a quick round-trip test against the configured model')
+    .option('-p, --prompt <text>', 'Prompt to send', 'Say "pong" and nothing else.')
+    .action(async (opts: { prompt: string }) => {
+      const { getContext, shutdownContext } = await import('../utils/bootstrap.js')
+      try {
+        const ctx = await getContext()
+        const llm = ctx.registry.getModels().find((m) => m.capabilities.llm && m.generate)
+        if (!llm || !llm.generate) {
+          log.fail('No LLM model registered')
+          process.exitCode = 1
+          return
+        }
+        log.info(`Testing ${llm.name}`)
+        log.dim(`> ${opts.prompt}`)
+        const start = Date.now()
+        let output = ''
+        let chunks = 0
+        for await (const chunk of llm.generate(opts.prompt, { maxTokens: 64, temperature: 0.1 })) {
+          output += chunk
+          chunks++
+        }
+        const elapsed = Date.now() - start
+        log.blank()
+        console.log(chalk.cyan(`< ${output.trim()}`))
+        log.blank()
+        log.ok(`Round-trip ok: ${chunks} chunks, ${elapsed}ms`)
+
+        // Embedding round-trip too
+        const embedder = ctx.registry.getModels().find((m) => m.capabilities.embedding && m.embed)
+        if (embedder && embedder.embed) {
+          const embStart = Date.now()
+          const result = await embedder.embed(['test'])
+          const dim = result.dense[0]?.length ?? 0
+          log.ok(`Embedding ok: ${dim}-dim, ${Date.now() - embStart}ms  (${embedder.name})`)
+        }
+      } catch (err) {
+        log.fail(`Test failed: ${(err as Error).message}`)
+        process.exitCode = 1
+      } finally {
+        await shutdownContext()
+      }
+    })
+
+  // ---------- switch ----------
+  cmd.command('switch')
+    .description('Change the active model provider (edits opendocuments.config.ts)')
+    .action(async () => {
+      const configPath = join(process.cwd(), 'opendocuments.config.ts')
+      if (!existsSync(configPath)) {
+        log.fail('No config file found in current directory.')
+        log.arrow('Run:  opendocuments init')
+        process.exitCode = 1
+        return
+      }
+
+      const { select, input } = await import('@inquirer/prompts')
+      const provider = await select({
+        message: 'Switch to provider:',
+        choices: [
+          { name: 'Ollama (local)', value: 'ollama' },
+          { name: 'OpenAI', value: 'openai' },
+          { name: 'Anthropic', value: 'anthropic' },
+          { name: 'Google', value: 'google' },
+          { name: 'Grok (xAI)', value: 'grok' },
+          { name: 'DeepSeek', value: 'deepseek' },
+          { name: 'Mistral', value: 'mistral' },
+          { name: 'OpenAI-compatible (vLLM/LM Studio/Groq/Together/…)', value: 'openai-compatible' },
+        ],
+      })
+
+      const defaults: Record<string, { llm: string; embedding: string; embeddingProvider?: string }> = {
+        ollama: { llm: 'qwen2.5:14b', embedding: 'bge-m3' },
+        openai: { llm: 'gpt-4o', embedding: 'text-embedding-3-small' },
+        anthropic: { llm: 'claude-sonnet-4-20250514', embedding: 'bge-m3', embeddingProvider: 'ollama' },
+        google: { llm: 'gemini-2.5-flash', embedding: 'text-embedding-004' },
+        grok: { llm: 'grok-4', embedding: 'grok-2-embed' },
+        deepseek: { llm: 'deepseek-chat', embedding: 'bge-m3', embeddingProvider: 'ollama' },
+        mistral: { llm: 'mistral-small-latest', embedding: 'mistral-embed' },
+        'openai-compatible': { llm: '', embedding: 'bge-m3', embeddingProvider: 'ollama' },
+      }
+
+      const llm = await input({ message: 'LLM model:', default: defaults[provider].llm })
+      const embedding = await input({ message: 'Embedding model:', default: defaults[provider].embedding })
+
+      let baseUrl = ''
+      if (provider === 'openai-compatible') {
+        baseUrl = await input({ message: 'baseUrl (OpenAI-compatible endpoint):', default: 'https://api.groq.com/openai/v1' })
+      }
+
+      const src = readFileSync(configPath, 'utf8')
+      const updated = rewriteModelBlock(src, {
+        provider,
+        llm,
+        embedding,
+        embeddingProvider: defaults[provider].embeddingProvider,
+        baseUrl,
+      })
+
+      writeFileSync(configPath, updated)
+      log.ok(`Updated ${configPath} → provider=${provider}, llm=${llm}`)
+      log.arrow('Restart:  opendocuments start')
+      if (provider !== 'ollama') {
+        const envVar = envVarName(provider)
+        log.arrow(`Set API key: export ${envVar}=...   (or put it in .env)`)
+      }
+    })
+
+  return cmd
+}
+
+/* ------------------------------------------------------------------ */
+/*  Config rewriting                                                  */
+/* ------------------------------------------------------------------ */
+
+interface ModelBlockUpdate {
+  provider: string
+  llm: string
+  embedding: string
+  embeddingProvider?: string
+  baseUrl?: string
+}
+
+/**
+ * Rewrite the `model: { ... }` block in opendocuments.config.ts.
+ * This is a best-effort string rewrite for the common cases produced by `init`.
+ * Preserves surrounding config — throws if the model block can't be located.
+ */
+export function rewriteModelBlock(src: string, update: ModelBlockUpdate): string {
+  const re = /model:\s*\{[\s\S]*?\n\s*\},/m
+  if (!re.test(src)) {
+    throw new Error('Could not locate `model: { ... }` block in config file — edit it manually.')
+  }
+
+  const lines = [
+    `model: {`,
+    `    provider: '${update.provider}',`,
+    update.llm ? `    llm: '${update.llm}',` : null,
+    `    embedding: '${update.embedding}',`,
+    update.embeddingProvider ? `    embeddingProvider: '${update.embeddingProvider}',` : null,
+    update.baseUrl ? `    baseUrl: '${update.baseUrl}',` : null,
+    update.provider !== 'ollama' ? `    apiKey: process.env.${envVarName(update.provider)},` : null,
+    update.embeddingProvider === 'openai' ? `    embeddingApiKey: process.env.OPENAI_API_KEY,` : null,
+    `  },`,
+  ].filter(Boolean).join('\n  ')
+
+  return src.replace(re, lines)
+}
+
+function envVarName(provider: string): string {
+  const map: Record<string, string> = {
+    openai: 'OPENAI_API_KEY',
+    anthropic: 'ANTHROPIC_API_KEY',
+    google: 'GOOGLE_API_KEY',
+    grok: 'XAI_API_KEY',
+    deepseek: 'DEEPSEEK_API_KEY',
+    mistral: 'MISTRAL_API_KEY',
+    'openai-compatible': 'OPENAI_COMPATIBLE_API_KEY',
+    ollama: 'OLLAMA_URL',
+  }
+  return map[provider] || 'API_KEY'
+}

--- a/packages/cli/src/commands/model.ts
+++ b/packages/cli/src/commands/model.ts
@@ -124,18 +124,19 @@ export function modelCommand() {
       }
     })
 
-  // ---------- pull ----------
-  cmd.command('pull <name>')
-    .description('Pull an Ollama model (checks disk space, shows progress)')
+  // ---------- pull (one or many) ----------
+  cmd.command('pull <names...>')
+    .description('Pull one or more Ollama models (checks disk space, shows progress)')
     .option('--base-url <url>', 'Ollama base URL', 'http://localhost:11434')
     .option('--yes', 'Skip disk space confirmation')
-    .action(async (name: string, opts: { baseUrl: string; yes?: boolean }) => {
+    .action(async (names: string[], opts: { baseUrl: string; yes?: boolean }) => {
       const reachable = await isOllamaRunning(opts.baseUrl)
       if (!reachable) {
         log.fail(`Ollama not reachable at ${opts.baseUrl}`)
         const install = getOllamaInstallCommand()
         if (install.supported) {
-          log.arrow(`Install:  ${install.command}`)
+          log.arrow(`Install:  opendocuments model install-ollama`)
+          log.arrow(`  or:     ${install.command}`)
         } else {
           log.arrow(`Download:  ${install.url}`)
         }
@@ -144,44 +145,169 @@ export function modelCommand() {
         return
       }
 
-      // Disk space pre-check
-      const estimate = estimateModelSize(name)
+      // Combined disk-space pre-check (sum across all requested models).
+      const estimates = names.map((n) => ({ name: n, size: estimateModelSize(n) }))
+      const totalEstimate = estimates.reduce((acc, e) => acc + (e.size ?? 0), 0)
       const available = getAvailableDiskBytes()
-      if (estimate && available !== null) {
-        const margin = 1.5e9 // keep 1.5GB headroom
-        log.info(`Estimated size:  ~${formatBytes(estimate)}`)
-        log.info(`Available disk:  ${formatBytes(available)}`)
-        if (available < estimate + margin) {
-          log.fail(
-            `Not enough free disk space (need ~${formatBytes(estimate + margin)}, have ${formatBytes(available)}).`,
-          )
-          if (!opts.yes) {
-            const { confirm } = await import('@inquirer/prompts')
-            const proceed = await confirm({ message: 'Pull anyway?', default: false })
-            if (!proceed) return
+      const margin = 1.5e9
+      if (totalEstimate > 0) {
+        log.info(`Estimated footprint:`)
+        for (const e of estimates) {
+          const line = e.size
+            ? `  ${e.name.padEnd(24)} ~${formatBytes(e.size)}`
+            : `  ${e.name.padEnd(24)} (size unknown)`
+          console.log(line)
+        }
+        if (names.length > 1) {
+          log.info(`  ${'total'.padEnd(24)} ~${formatBytes(totalEstimate)}`)
+        }
+        if (available !== null) {
+          log.info(`Available disk:  ${formatBytes(available)}`)
+          if (available < totalEstimate + margin) {
+            log.fail(
+              `Not enough free disk space (need ~${formatBytes(totalEstimate + margin)}, have ${formatBytes(available)}).`,
+            )
+            if (!opts.yes) {
+              const { confirm } = await import('@inquirer/prompts')
+              const proceed = await confirm({ message: 'Pull anyway?', default: false })
+              if (!proceed) return
+            }
           }
         }
-      } else if (estimate) {
-        log.info(`Estimated size: ~${formatBytes(estimate)} (disk-free lookup unavailable)`)
       }
 
-      log.wait(`Pulling ${chalk.cyan(name)} ...`)
-      let lastPrinted = ''
-      const ok = await pullOllamaModel(name, opts.baseUrl, (line) => {
-        if (line !== lastPrinted) {
-          lastPrinted = line
-          process.stdout.write(`\r\x1b[K  ${line}`)
+      const failures: string[] = []
+      for (const [i, name] of names.entries()) {
+        if (names.length > 1) {
+          log.blank()
+          log.heading(`[${i + 1}/${names.length}] ${name}`)
         }
-      })
-      process.stdout.write('\n')
+        log.wait(`Pulling ${chalk.cyan(name)} ...`)
+        let lastPrinted = ''
+        const ok = await pullOllamaModel(name, opts.baseUrl, (line) => {
+          if (line !== lastPrinted) {
+            lastPrinted = line
+            process.stdout.write(`\r\x1b[K  ${line}`)
+          }
+        })
+        process.stdout.write('\n')
 
-      if (ok) {
-        log.ok(`Pulled ${name}`)
-      } else {
-        log.fail(`Failed to pull ${name}`)
-        log.arrow(`Try manually:  ollama pull ${name}`)
+        if (ok) log.ok(`Pulled ${name}`)
+        else {
+          log.fail(`Failed to pull ${name}`)
+          failures.push(name)
+        }
+      }
+
+      if (failures.length > 0) {
+        log.blank()
+        log.fail(`${failures.length}/${names.length} pulls failed: ${failures.join(', ')}`)
+        log.arrow(`Retry manually:  ${failures.map((f) => `ollama pull ${f}`).join(' && ')}`)
         process.exitCode = 1
       }
+    })
+
+  // ---------- install-ollama ----------
+  cmd.command('install-ollama')
+    .description('Install Ollama via the official script (macOS/Linux)')
+    .option('--yes', 'Skip confirmation')
+    .action(async (opts: { yes?: boolean }) => {
+      const install = getOllamaInstallCommand()
+      if (!install.supported) {
+        log.fail('Automatic install is not supported on this platform (Windows).')
+        log.arrow(`Download manually: ${install.url}`)
+        process.exitCode = 1
+        return
+      }
+
+      if (await isOllamaRunning()) {
+        log.ok('Ollama is already running at http://localhost:11434')
+        return
+      }
+
+      log.info('About to run the official Ollama install script:')
+      log.dim(`  ${install.command}`)
+      log.blank()
+      if (!opts.yes) {
+        const { confirm } = await import('@inquirer/prompts')
+        const go = await confirm({ message: 'Proceed?', default: true })
+        if (!go) return
+      }
+
+      const { execSync } = await import('node:child_process')
+      try {
+        execSync(install.command!, { stdio: 'inherit' })
+      } catch (err) {
+        log.fail(`Install failed: ${(err as Error).message}`)
+        process.exitCode = 1
+        return
+      }
+
+      log.wait('Waiting for Ollama daemon to come up...')
+      for (let i = 0; i < 10; i++) {
+        await new Promise((r) => setTimeout(r, 1500))
+        if (await isOllamaRunning()) {
+          log.ok('Ollama is running')
+          log.arrow('Next: opendocuments model pull gemma3:12b')
+          return
+        }
+      }
+      log.fail('Ollama did not come up within 15s. Try: ollama serve')
+      process.exitCode = 1
+    })
+
+  // ---------- set-key ----------
+  cmd.command('set-key <provider>')
+    .description('Save an API key to .env for the given provider')
+    .option('--key <value>', 'Pass the key inline (otherwise prompted)')
+    .option('--env-file <path>', 'Path to .env file', '.env')
+    .action(async (provider: string, opts: { key?: string; envFile: string }) => {
+      const envVar = envVarForProvider(provider)
+      if (!envVar) {
+        log.fail(`Unknown provider: ${provider}`)
+        log.arrow('Supported: openai, anthropic, google, grok, deepseek, mistral, openai-compatible')
+        process.exitCode = 1
+        return
+      }
+
+      let key = opts.key
+      if (!key) {
+        const { password } = await import('@inquirer/prompts')
+        key = await password({ message: `Enter ${envVar} (input hidden):`, mask: '*' })
+      }
+      if (!key) {
+        log.fail('Empty key — aborting.')
+        process.exitCode = 1
+        return
+      }
+
+      const envPath = join(process.cwd(), opts.envFile)
+      const existing = existsSync(envPath) ? readFileSync(envPath, 'utf8') : ''
+      const pattern = new RegExp(`^${envVar}=.*$`, 'm')
+
+      let next: string
+      if (pattern.test(existing)) {
+        next = existing.replace(pattern, `${envVar}=${key}`)
+      } else {
+        const needsNewline = existing && !existing.endsWith('\n')
+        next = existing + (needsNewline ? '\n' : '') + `${envVar}=${key}\n`
+      }
+      writeFileSync(envPath, next)
+      log.ok(`Wrote ${envVar} to ${chalk.cyan(opts.envFile)}`)
+
+      // gitignore sanity check
+      const gitignorePath = join(process.cwd(), '.gitignore')
+      if (existsSync(gitignorePath)) {
+        const gi = readFileSync(gitignorePath, 'utf8')
+        if (!/^\.env($|\n)/m.test(gi) && !gi.split('\n').some((l) => l.trim() === '.env')) {
+          log.fail('.env is NOT in .gitignore — your key could leak if committed.')
+          log.arrow('Add to .gitignore:  .env')
+        }
+      } else {
+        log.info('No .gitignore found — consider creating one with `.env` listed.')
+      }
+
+      log.arrow('Validate with:  opendocuments doctor')
     })
 
   // ---------- rm ----------
@@ -366,4 +492,18 @@ function envVarName(provider: string): string {
     ollama: 'OLLAMA_URL',
   }
   return map[provider] || 'API_KEY'
+}
+
+/** Like envVarName but returns null for unknown providers (used by set-key). */
+function envVarForProvider(provider: string): string | null {
+  const map: Record<string, string> = {
+    openai: 'OPENAI_API_KEY',
+    anthropic: 'ANTHROPIC_API_KEY',
+    google: 'GOOGLE_API_KEY',
+    grok: 'XAI_API_KEY',
+    deepseek: 'DEEPSEEK_API_KEY',
+    mistral: 'MISTRAL_API_KEY',
+    'openai-compatible': 'OPENAI_COMPATIBLE_API_KEY',
+  }
+  return map[provider] ?? null
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,7 @@ import { stopCommand } from './commands/stop.js'
 import { searchCommand } from './commands/search.js'
 import { completionCommand } from './commands/completion.js'
 import { upgradeCommand } from './commands/upgrade.js'
+import { modelCommand } from './commands/model.js'
 
 const program = new Command()
 program
@@ -41,5 +42,6 @@ program.addCommand(stopCommand())
 program.addCommand(searchCommand())
 program.addCommand(completionCommand())
 program.addCommand(upgradeCommand())
+program.addCommand(modelCommand())
 
 program.parse()

--- a/packages/cli/src/utils/ollama.ts
+++ b/packages/cli/src/utils/ollama.ts
@@ -1,0 +1,196 @@
+import { statfsSync } from 'node:fs'
+import { homedir, platform } from 'node:os'
+
+export interface OllamaModelInfo {
+  name: string
+  size: number
+  digest?: string
+  modified_at?: string
+  details?: {
+    parameter_size?: string
+    quantization_level?: string
+    family?: string
+  }
+}
+
+export async function isOllamaRunning(baseUrl = 'http://localhost:11434'): Promise<boolean> {
+  try {
+    const res = await fetch(`${baseUrl}/api/tags`, { signal: AbortSignal.timeout(3000) })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+export async function listOllamaModels(baseUrl = 'http://localhost:11434'): Promise<OllamaModelInfo[]> {
+  try {
+    const res = await fetch(`${baseUrl}/api/tags`, { signal: AbortSignal.timeout(5000) })
+    if (!res.ok) return []
+    const data = (await res.json()) as { models?: OllamaModelInfo[] }
+    return data.models ?? []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Pull an Ollama model with progress streaming.
+ * Yields human-readable progress lines; resolves with true on success, false on failure.
+ */
+export async function pullOllamaModel(
+  model: string,
+  baseUrl = 'http://localhost:11434',
+  onProgress?: (line: string) => void,
+): Promise<boolean> {
+  try {
+    const res = await fetch(`${baseUrl}/api/pull`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model, stream: true }),
+    })
+    if (!res.ok || !res.body) return false
+
+    const reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+    let lastStatus = ''
+
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split('\n')
+      buffer = lines.pop() || ''
+      for (const line of lines) {
+        if (!line.trim()) continue
+        try {
+          const evt = JSON.parse(line) as {
+            status?: string
+            total?: number
+            completed?: number
+            error?: string
+          }
+          if (evt.error) {
+            onProgress?.(`error: ${evt.error}`)
+            return false
+          }
+          if (evt.status && evt.status !== lastStatus) {
+            lastStatus = evt.status
+            if (evt.total && evt.completed !== undefined) {
+              const pct = ((evt.completed / evt.total) * 100).toFixed(1)
+              onProgress?.(`${evt.status} — ${pct}% (${formatBytes(evt.completed)}/${formatBytes(evt.total)})`)
+            } else {
+              onProgress?.(evt.status)
+            }
+          } else if (evt.status === lastStatus && evt.total && evt.completed !== undefined) {
+            const pct = ((evt.completed / evt.total) * 100).toFixed(1)
+            onProgress?.(`${evt.status} — ${pct}%`)
+          }
+        } catch {
+          // skip unparseable lines
+        }
+      }
+    }
+    return true
+  } catch (err) {
+    onProgress?.(`error: ${(err as Error).message}`)
+    return false
+  }
+}
+
+export async function deleteOllamaModel(
+  model: string,
+  baseUrl = 'http://localhost:11434',
+): Promise<boolean> {
+  try {
+    const res = await fetch(`${baseUrl}/api/delete`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model }),
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Best-effort available disk space in bytes for a given directory. Returns null on
+ * unsupported platforms or permission errors.
+ */
+export function getAvailableDiskBytes(dir: string = homedir()): number | null {
+  try {
+    const stat = statfsSync(dir)
+    return Number(stat.bavail) * Number(stat.bsize)
+  } catch {
+    return null
+  }
+}
+
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return '?'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let v = bytes
+  let i = 0
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++ }
+  return `${v.toFixed(i === 0 ? 0 : 1)}${units[i]}`
+}
+
+/**
+ * Rough estimate of disk footprint per Ollama model tag.
+ * Used for pre-pull warnings only; Ollama will be authoritative at pull time.
+ */
+const MODEL_SIZE_HINTS: Record<string, number> = {
+  // llama family
+  'llama3.3:8b': 5e9,
+  'llama4:scout': 65e9,
+  'llama4:maverick': 230e9,
+  // qwen
+  'qwen2.5:7b': 4.7e9,
+  'qwen2.5:14b': 9e9,
+  'qwen2.5:32b': 20e9,
+  'qwen3.5:9b': 5.5e9,
+  'qwen3.5:27b': 17e9,
+  // gemma
+  'gemma2:2b': 1.6e9,
+  'gemma2:9b': 5.4e9,
+  'gemma3:1b': 0.8e9,
+  'gemma3:4b': 2.5e9,
+  'gemma3:12b': 7.5e9,
+  'gemma3:27b': 17e9,
+  'gemma3n': 2.8e9,
+  // deepseek
+  'deepseek-r1:7b': 4.7e9,
+  'deepseek-r1:14b': 9e9,
+  'deepseek-r1:32b': 20e9,
+  // phi
+  'phi4:14b': 9e9,
+  // embedding
+  'bge-m3': 1.2e9,
+  'nomic-embed-text': 0.3e9,
+  'mxbai-embed-large': 0.7e9,
+}
+
+export function estimateModelSize(tag: string): number | null {
+  const lower = tag.toLowerCase()
+  if (MODEL_SIZE_HINTS[lower]) return MODEL_SIZE_HINTS[lower]
+  // Fuzzy match by prefix (e.g. "gemma3:27b-instruct-q4_0" → "gemma3:27b")
+  for (const [k, v] of Object.entries(MODEL_SIZE_HINTS)) {
+    if (lower.startsWith(k)) return v
+  }
+  return null
+}
+
+/**
+ * Offer to install Ollama via the official install script. Returns true if the
+ * platform is supported and install script exists. Never runs without the caller
+ * confirming — this just resolves the install approach.
+ */
+export function getOllamaInstallCommand(): { supported: boolean; command?: string; url: string } {
+  const p = platform()
+  const url = 'https://ollama.com/download'
+  if (p === 'darwin' || p === 'linux') {
+    return { supported: true, command: 'curl -fsSL https://ollama.com/install.sh | sh', url }
+  }
+  return { supported: false, url }
+}

--- a/packages/cli/tests/commands/ask.test.ts
+++ b/packages/cli/tests/commands/ask.test.ts
@@ -10,7 +10,12 @@ describe('ask command logic', () => {
 
   beforeEach(async () => {
     tempDir = mkdtempSync(join(tmpdir(), 'opendocuments-test-'))
-    ctx = await bootstrap({ dataDir: tempDir })
+    ctx = await bootstrap({
+      dataDir: tempDir,
+      configOverrides: {
+        model: { provider: 'test-stub', llm: 'stub-llm', embedding: 'stub-embedding' },
+      },
+    })
   })
   afterEach(async () => { await ctx.shutdown(); rmSync(tempDir, { recursive: true, force: true }) })
 

--- a/packages/cli/tests/commands/doctor.test.ts
+++ b/packages/cli/tests/commands/doctor.test.ts
@@ -10,7 +10,12 @@ describe('doctor command logic', () => {
 
   beforeEach(async () => {
     tempDir = mkdtempSync(join(tmpdir(), 'opendocuments-test-'))
-    ctx = await bootstrap({ dataDir: tempDir })
+    ctx = await bootstrap({
+      dataDir: tempDir,
+      configOverrides: {
+        model: { provider: 'test-stub', llm: 'stub-llm', embedding: 'stub-embedding' },
+      },
+    })
   })
   afterEach(async () => { await ctx.shutdown(); rmSync(tempDir, { recursive: true, force: true }) })
 

--- a/packages/cli/tests/commands/model.test.ts
+++ b/packages/cli/tests/commands/model.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { rewriteModelBlock } from '../../src/commands/model.js'
+
+const SAMPLE_CONFIG = `import { defineConfig } from 'opendocuments-core'
+
+export default defineConfig({
+  workspace: 'demo',
+  mode: 'personal',
+
+  model: {
+    provider: 'ollama',
+    llm: 'qwen2.5:14b',
+    embedding: 'bge-m3',
+  },
+
+  rag: {
+    profile: 'balanced',
+  },
+})
+`
+
+describe('rewriteModelBlock', () => {
+  it('switches to a cloud provider and adds apiKey', () => {
+    const out = rewriteModelBlock(SAMPLE_CONFIG, {
+      provider: 'deepseek',
+      llm: 'deepseek-chat',
+      embedding: 'bge-m3',
+      embeddingProvider: 'ollama',
+    })
+    expect(out).toContain(`provider: 'deepseek',`)
+    expect(out).toContain(`llm: 'deepseek-chat',`)
+    expect(out).toContain(`embeddingProvider: 'ollama',`)
+    expect(out).toContain(`apiKey: process.env.DEEPSEEK_API_KEY,`)
+    // Outside model block is preserved
+    expect(out).toContain(`profile: 'balanced',`)
+  })
+
+  it('supports openai-compatible provider with baseUrl', () => {
+    const out = rewriteModelBlock(SAMPLE_CONFIG, {
+      provider: 'openai-compatible',
+      llm: 'llama-4-70b',
+      embedding: 'bge-m3',
+      embeddingProvider: 'ollama',
+      baseUrl: 'https://api.groq.com/openai/v1',
+    })
+    expect(out).toContain(`baseUrl: 'https://api.groq.com/openai/v1',`)
+    expect(out).toContain(`apiKey: process.env.OPENAI_COMPATIBLE_API_KEY,`)
+  })
+
+  it('round-trips back to ollama without apiKey line', () => {
+    const withCloud = rewriteModelBlock(SAMPLE_CONFIG, {
+      provider: 'openai',
+      llm: 'gpt-4o',
+      embedding: 'text-embedding-3-small',
+    })
+    const back = rewriteModelBlock(withCloud, {
+      provider: 'ollama',
+      llm: 'gemma3:12b',
+      embedding: 'bge-m3',
+    })
+    expect(back).toContain(`provider: 'ollama',`)
+    expect(back).toContain(`llm: 'gemma3:12b',`)
+    expect(back).not.toContain('apiKey: process.env')
+  })
+
+  it('throws when model block is missing', () => {
+    expect(() => rewriteModelBlock('export default {}', {
+      provider: 'openai',
+      llm: 'x',
+      embedding: 'y',
+    })).toThrow(/model:/)
+  })
+})

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -45,6 +45,9 @@ const PROVIDER_MAP: Record<string, string> = {
   anthropic: 'opendocuments-model-anthropic',
   google: 'opendocuments-model-google',
   grok: 'opendocuments-model-grok',
+  deepseek: 'opendocuments-model-deepseek',
+  mistral: 'opendocuments-model-mistral',
+  'openai-compatible': 'opendocuments-model-openai-compatible',
 }
 
 const EMBEDDING_DIMENSIONS: Record<string, number> = {
@@ -52,6 +55,7 @@ const EMBEDDING_DIMENSIONS: Record<string, number> = {
   openai: 1536,
   google: 768,
   grok: 1536,
+  mistral: 1024,
   default: 384,
 }
 

--- a/plugins/model-deepseek/package.json
+++ b/plugins/model-deepseek/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "opendocuments-model-deepseek",
+  "version": "0.1.0",
+  "description": "DeepSeek model provider plugin for OpenDocuments (V3.2, R1, V4 — OpenAI-compatible)",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "opendocuments-core": "0.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "vitest": "^2.1.0"
+  },
+  "peerDependencies": {
+    "opendocuments-core": "^0.1.0"
+  },
+  "license": "MIT",
+  "files": [
+    "dist/**/*"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joungminsung/OpenDocuments.git",
+    "directory": "plugins/model-deepseek"
+  }
+}

--- a/plugins/model-deepseek/package.json
+++ b/plugins/model-deepseek/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendocuments-model-deepseek",
   "version": "0.1.0",
-  "description": "DeepSeek model provider plugin for OpenDocuments (V3.2, R1, V4 — OpenAI-compatible)",
+  "description": "DeepSeek model provider for OpenDocuments self-hosted RAG",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -18,14 +18,14 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "opendocuments-core": "0.1.0"
+    "opendocuments-core": "0.3.0"
   },
   "devDependencies": {
     "typescript": "^5.5.0",
     "vitest": "^2.1.0"
   },
   "peerDependencies": {
-    "opendocuments-core": "^0.1.0"
+    "opendocuments-core": "^0.3.0"
   },
   "license": "MIT",
   "files": [
@@ -35,5 +35,24 @@
     "type": "git",
     "url": "https://github.com/joungminsung/OpenDocuments.git",
     "directory": "plugins/model-deepseek"
-  }
+  },
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "model-provider",
+    "deepseek",
+    "reasoning-model",
+    "openai-compatible"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors"
 }

--- a/plugins/model-deepseek/src/index.ts
+++ b/plugins/model-deepseek/src/index.ts
@@ -1,0 +1,112 @@
+import type {
+  ModelPlugin,
+  PluginContext,
+  HealthStatus,
+  GenerateOpts,
+} from 'opendocuments-core'
+import { fetchWithTimeout } from 'opendocuments-core'
+
+export interface DeepSeekConfig {
+  apiKey?: string
+  baseUrl?: string
+  llmModel?: string
+}
+
+/**
+ * DeepSeek model plugin.
+ *
+ * DeepSeek exposes an OpenAI-compatible Chat Completions API but does not
+ * currently provide an embeddings endpoint. Pair this plugin with a secondary
+ * embedding provider (e.g. ollama `bge-m3` or openai `text-embedding-3-small`)
+ * by setting `embeddingProvider` in the config.
+ *
+ * Supported models (April 2026):
+ *  - `deepseek-chat`     — DeepSeek-V3.2 hybrid thinking (default)
+ *  - `deepseek-reasoner` — DeepSeek-R1 reasoning-only
+ *  - `deepseek-v4`       — upcoming flagship (1M context, multimodal)
+ */
+export class DeepSeekModelPlugin implements ModelPlugin {
+  name = '@opendocuments/model-deepseek'
+  type = 'model' as const
+  version = '0.1.0'
+  coreVersion = '^0.1.0'
+  capabilities = { llm: true, embedding: false, reranker: false, vision: false }
+
+  private apiKey = ''
+  private baseUrl = 'https://api.deepseek.com/v1'
+  private llmModel = 'deepseek-chat'
+
+  async setup(ctx: PluginContext): Promise<void> {
+    const config = ctx.config as DeepSeekConfig
+    this.apiKey = config.apiKey || process.env.DEEPSEEK_API_KEY || ''
+    if (config.baseUrl) this.baseUrl = config.baseUrl
+    if (config.llmModel) this.llmModel = config.llmModel
+  }
+
+  async healthCheck(): Promise<HealthStatus> {
+    if (!this.apiKey) return { healthy: false, message: 'DEEPSEEK_API_KEY not set' }
+    try {
+      const res = await fetchWithTimeout(`${this.baseUrl}/models`, {
+        headers: { Authorization: `Bearer ${this.apiKey}` },
+      }, 10000)
+      return { healthy: res.ok, message: res.ok ? 'Connected' : `HTTP ${res.status}` }
+    } catch (err) {
+      return { healthy: false, message: (err as Error).message }
+    }
+  }
+
+  async *generate(prompt: string, opts?: GenerateOpts): AsyncIterable<string> {
+    const messages: { role: string; content: string }[] = []
+    if (opts?.systemPrompt) messages.push({ role: 'system', content: opts.systemPrompt })
+    messages.push({ role: 'user', content: prompt })
+
+    const res = await fetchWithTimeout(`${this.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.llmModel,
+        messages,
+        stream: true,
+        temperature: opts?.temperature ?? 0.3,
+        max_tokens: opts?.maxTokens,
+        stop: opts?.stop,
+      }),
+    }, 180000)
+
+    if (!res.ok) throw new Error(`DeepSeek error: ${res.status}`)
+    if (!res.body) throw new Error('No response body')
+
+    const reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() || ''
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue
+          const data = line.slice(6).trim()
+          if (data === '[DONE]') return
+          try {
+            const parsed = JSON.parse(data)
+            const content = parsed.choices?.[0]?.delta?.content
+            if (content) yield content
+          } catch {
+            // skip malformed chunks
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock()
+    }
+  }
+}
+
+export default DeepSeekModelPlugin

--- a/plugins/model-deepseek/tests/deepseek.test.ts
+++ b/plugins/model-deepseek/tests/deepseek.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { DeepSeekModelPlugin } from '../src/index.js'
+
+describe('DeepSeekModelPlugin', () => {
+  let plugin: DeepSeekModelPlugin
+
+  beforeEach(async () => {
+    plugin = new DeepSeekModelPlugin()
+    await plugin.setup({
+      config: { apiKey: 'test-api-key' },
+      dataDir: '/tmp',
+      log: console as any,
+    } as any)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('has correct metadata', () => {
+    expect(plugin.name).toBe('@opendocuments/model-deepseek')
+    expect(plugin.type).toBe('model')
+    expect(plugin.capabilities.llm).toBe(true)
+    expect(plugin.capabilities.embedding).toBe(false)
+  })
+
+  it('uses deepseek-chat as default model', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('data: [DONE]\n\n'))
+            controller.close()
+          },
+        }),
+      }),
+    )
+    for await (const _ of plugin.generate('hi')) { /* drain */ }
+    const call = vi.mocked(fetch).mock.calls[0]
+    const body = JSON.parse((call[1] as any).body)
+    expect(body.model).toBe('deepseek-chat')
+  })
+
+  it('healthCheck reports missing API key', async () => {
+    const p = new DeepSeekModelPlugin()
+    const origEnv = process.env.DEEPSEEK_API_KEY
+    delete process.env.DEEPSEEK_API_KEY
+    await p.setup({ config: {}, dataDir: '/tmp', log: console as any } as any)
+    const status = await p.healthCheck()
+    expect(status.healthy).toBe(false)
+    expect(status.message).toBe('DEEPSEEK_API_KEY not set')
+    if (origEnv !== undefined) process.env.DEEPSEEK_API_KEY = origEnv
+  })
+
+  it('generate streams SSE chunks', async () => {
+    const encoder = new TextEncoder()
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"Hello "}}]}\n\n'))
+        controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"DeepSeek"}}]}\n\n'))
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+        controller.close()
+      },
+    })
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, body: stream }))
+
+    const tokens: string[] = []
+    for await (const t of plugin.generate('hi')) tokens.push(t)
+    expect(tokens).toEqual(['Hello ', 'DeepSeek'])
+  })
+
+  it('honors custom llmModel from config', async () => {
+    const p = new DeepSeekModelPlugin()
+    await p.setup({
+      config: { apiKey: 'k', llmModel: 'deepseek-reasoner' },
+      dataDir: '/tmp',
+      log: console as any,
+    } as any)
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      body: new ReadableStream({
+        start(c) { c.enqueue(new TextEncoder().encode('data: [DONE]\n\n')); c.close() },
+      }),
+    }))
+    for await (const _ of p.generate('q')) { /* drain */ }
+    const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as any).body)
+    expect(body.model).toBe('deepseek-reasoner')
+  })
+})

--- a/plugins/model-deepseek/tsconfig.json
+++ b/plugins/model-deepseek/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["tests/**/*", "dist"]
+}

--- a/plugins/model-deepseek/vitest.config.ts
+++ b/plugins/model-deepseek/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+})

--- a/plugins/model-mistral/package.json
+++ b/plugins/model-mistral/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "opendocuments-model-mistral",
+  "version": "0.1.0",
+  "description": "Mistral AI model provider plugin for OpenDocuments (Small 4, Large, Codestral, Pixtral, Voxtral)",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "opendocuments-core": "0.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "vitest": "^2.1.0"
+  },
+  "peerDependencies": {
+    "opendocuments-core": "^0.1.0"
+  },
+  "license": "MIT",
+  "files": [
+    "dist/**/*"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joungminsung/OpenDocuments.git",
+    "directory": "plugins/model-mistral"
+  }
+}

--- a/plugins/model-mistral/package.json
+++ b/plugins/model-mistral/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendocuments-model-mistral",
   "version": "0.1.0",
-  "description": "Mistral AI model provider plugin for OpenDocuments (Small 4, Large, Codestral, Pixtral, Voxtral)",
+  "description": "Mistral model provider for OpenDocuments self-hosted RAG",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -18,14 +18,14 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "opendocuments-core": "0.1.0"
+    "opendocuments-core": "0.3.0"
   },
   "devDependencies": {
     "typescript": "^5.5.0",
     "vitest": "^2.1.0"
   },
   "peerDependencies": {
-    "opendocuments-core": "^0.1.0"
+    "opendocuments-core": "^0.3.0"
   },
   "license": "MIT",
   "files": [
@@ -35,5 +35,24 @@
     "type": "git",
     "url": "https://github.com/joungminsung/OpenDocuments.git",
     "directory": "plugins/model-mistral"
-  }
+  },
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "model-provider",
+    "mistral",
+    "codestral",
+    "embeddings"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors"
 }

--- a/plugins/model-mistral/src/index.ts
+++ b/plugins/model-mistral/src/index.ts
@@ -1,0 +1,135 @@
+import type {
+  ModelPlugin,
+  PluginContext,
+  HealthStatus,
+  GenerateOpts,
+  EmbeddingResult,
+} from 'opendocuments-core'
+import { fetchWithTimeout } from 'opendocuments-core'
+
+export interface MistralConfig {
+  apiKey?: string
+  baseUrl?: string
+  llmModel?: string
+  embeddingModel?: string
+}
+
+/**
+ * Mistral AI model plugin.
+ *
+ * Mistral exposes an OpenAI-compatible Chat Completions API plus a first-party
+ * embeddings endpoint (`mistral-embed`, 1024-dim).
+ *
+ * Supported models (April 2026):
+ *  - `mistral-small-latest`   — Mistral Small 4 MoE (default, multimodal + reasoning + code)
+ *  - `mistral-large-latest`   — Mistral Large 2.1 (flagship reasoning)
+ *  - `codestral-latest`       — code specialist
+ *  - `pixtral-large-latest`   — legacy vision (deprecated, prefer Small 4)
+ *
+ * Embedding: `mistral-embed` (default, 1024 dimensions).
+ */
+export class MistralModelPlugin implements ModelPlugin {
+  name = '@opendocuments/model-mistral'
+  type = 'model' as const
+  version = '0.1.0'
+  coreVersion = '^0.1.0'
+  capabilities = { llm: true, embedding: true, reranker: false, vision: true }
+
+  private apiKey = ''
+  private baseUrl = 'https://api.mistral.ai/v1'
+  private llmModel = 'mistral-small-latest'
+  private embeddingModel = 'mistral-embed'
+
+  async setup(ctx: PluginContext): Promise<void> {
+    const config = ctx.config as MistralConfig
+    this.apiKey = config.apiKey || process.env.MISTRAL_API_KEY || ''
+    if (config.baseUrl) this.baseUrl = config.baseUrl
+    if (config.llmModel) this.llmModel = config.llmModel
+    if (config.embeddingModel) this.embeddingModel = config.embeddingModel
+  }
+
+  async healthCheck(): Promise<HealthStatus> {
+    if (!this.apiKey) return { healthy: false, message: 'MISTRAL_API_KEY not set' }
+    try {
+      const res = await fetchWithTimeout(`${this.baseUrl}/models`, {
+        headers: { Authorization: `Bearer ${this.apiKey}` },
+      }, 10000)
+      return { healthy: res.ok, message: res.ok ? 'Connected' : `HTTP ${res.status}` }
+    } catch (err) {
+      return { healthy: false, message: (err as Error).message }
+    }
+  }
+
+  async *generate(prompt: string, opts?: GenerateOpts): AsyncIterable<string> {
+    const messages: { role: string; content: string }[] = []
+    if (opts?.systemPrompt) messages.push({ role: 'system', content: opts.systemPrompt })
+    messages.push({ role: 'user', content: prompt })
+
+    const res = await fetchWithTimeout(`${this.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.llmModel,
+        messages,
+        stream: true,
+        temperature: opts?.temperature ?? 0.3,
+        max_tokens: opts?.maxTokens,
+        stop: opts?.stop,
+      }),
+    }, 120000)
+
+    if (!res.ok) throw new Error(`Mistral error: ${res.status}`)
+    if (!res.body) throw new Error('No response body')
+
+    const reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() || ''
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue
+          const data = line.slice(6).trim()
+          if (data === '[DONE]') return
+          try {
+            const parsed = JSON.parse(data)
+            const content = parsed.choices?.[0]?.delta?.content
+            if (content) yield content
+          } catch {
+            // skip malformed chunks
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock()
+    }
+  }
+
+  async embed(texts: string[]): Promise<EmbeddingResult> {
+    const res = await fetchWithTimeout(`${this.baseUrl}/embeddings`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.embeddingModel,
+        input: texts,
+      }),
+    }, 30000)
+
+    if (!res.ok) throw new Error(`Mistral embed error: ${res.status}`)
+    const data = (await res.json()) as { data: { embedding: number[] }[] }
+    return { dense: data.data.map((d) => d.embedding) }
+  }
+}
+
+export default MistralModelPlugin

--- a/plugins/model-mistral/tests/mistral.test.ts
+++ b/plugins/model-mistral/tests/mistral.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { MistralModelPlugin } from '../src/index.js'
+
+describe('MistralModelPlugin', () => {
+  let plugin: MistralModelPlugin
+
+  beforeEach(async () => {
+    plugin = new MistralModelPlugin()
+    await plugin.setup({
+      config: { apiKey: 'test-api-key' },
+      dataDir: '/tmp',
+      log: console as any,
+    } as any)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('has correct metadata', () => {
+    expect(plugin.name).toBe('@opendocuments/model-mistral')
+    expect(plugin.capabilities.llm).toBe(true)
+    expect(plugin.capabilities.embedding).toBe(true)
+    expect(plugin.capabilities.vision).toBe(true)
+  })
+
+  it('uses mistral-small-latest as default LLM', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      body: new ReadableStream({
+        start(c) { c.enqueue(new TextEncoder().encode('data: [DONE]\n\n')); c.close() },
+      }),
+    }))
+    for await (const _ of plugin.generate('hi')) { /* drain */ }
+    const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as any).body)
+    expect(body.model).toBe('mistral-small-latest')
+  })
+
+  it('embed uses mistral-embed by default and returns dense vectors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { embedding: [0.1, 0.2] },
+          { embedding: [0.3, 0.4] },
+        ],
+      }),
+    }))
+    const result = await plugin.embed(['a', 'b'])
+    expect(result.dense).toEqual([[0.1, 0.2], [0.3, 0.4]])
+    const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as any).body)
+    expect(body.model).toBe('mistral-embed')
+  })
+
+  it('healthCheck reports missing API key', async () => {
+    const p = new MistralModelPlugin()
+    const origEnv = process.env.MISTRAL_API_KEY
+    delete process.env.MISTRAL_API_KEY
+    await p.setup({ config: {}, dataDir: '/tmp', log: console as any } as any)
+    const status = await p.healthCheck()
+    expect(status.healthy).toBe(false)
+    expect(status.message).toBe('MISTRAL_API_KEY not set')
+    if (origEnv !== undefined) process.env.MISTRAL_API_KEY = origEnv
+  })
+})

--- a/plugins/model-mistral/tsconfig.json
+++ b/plugins/model-mistral/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["tests/**/*", "dist"]
+}

--- a/plugins/model-mistral/vitest.config.ts
+++ b/plugins/model-mistral/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+})

--- a/plugins/model-openai-compatible/package.json
+++ b/plugins/model-openai-compatible/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "opendocuments-model-openai-compatible",
+  "version": "0.1.0",
+  "description": "Generic OpenAI-compatible model provider for vLLM, LM Studio, Together, Fireworks, Groq, DeepInfra, SiliconFlow, and other compatible endpoints",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "opendocuments-core": "0.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "vitest": "^2.1.0"
+  },
+  "peerDependencies": {
+    "opendocuments-core": "^0.1.0"
+  },
+  "license": "MIT",
+  "files": [
+    "dist/**/*"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joungminsung/OpenDocuments.git",
+    "directory": "plugins/model-openai-compatible"
+  }
+}

--- a/plugins/model-openai-compatible/package.json
+++ b/plugins/model-openai-compatible/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendocuments-model-openai-compatible",
   "version": "0.1.0",
-  "description": "Generic OpenAI-compatible model provider for vLLM, LM Studio, Together, Fireworks, Groq, DeepInfra, SiliconFlow, and other compatible endpoints",
+  "description": "OpenAI-compatible model provider for OpenDocuments self-hosted RAG",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -18,14 +18,14 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "opendocuments-core": "0.1.0"
+    "opendocuments-core": "0.3.0"
   },
   "devDependencies": {
     "typescript": "^5.5.0",
     "vitest": "^2.1.0"
   },
   "peerDependencies": {
-    "opendocuments-core": "^0.1.0"
+    "opendocuments-core": "^0.3.0"
   },
   "license": "MIT",
   "files": [
@@ -35,5 +35,25 @@
     "type": "git",
     "url": "https://github.com/joungminsung/OpenDocuments.git",
     "directory": "plugins/model-openai-compatible"
-  }
+  },
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "model-provider",
+    "openai-compatible",
+    "vllm",
+    "lm-studio",
+    "openrouter"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors"
 }

--- a/plugins/model-openai-compatible/src/index.ts
+++ b/plugins/model-openai-compatible/src/index.ts
@@ -1,0 +1,170 @@
+import type {
+  ModelPlugin,
+  PluginContext,
+  HealthStatus,
+  GenerateOpts,
+  EmbeddingResult,
+} from 'opendocuments-core'
+import { fetchWithTimeout } from 'opendocuments-core'
+
+export interface OpenAICompatibleConfig {
+  apiKey?: string
+  /** Required. Base URL of the OpenAI-compatible endpoint (include /v1 suffix if applicable). */
+  baseUrl?: string
+  llmModel?: string
+  embeddingModel?: string
+  /** Disable embedding even if the endpoint supports it (useful when pairing with another embedder). */
+  disableEmbedding?: boolean
+  /** Extra headers to attach to every request (e.g. `HTTP-Referer` for OpenRouter). */
+  extraHeaders?: Record<string, string>
+}
+
+/**
+ * Generic OpenAI-compatible model plugin.
+ *
+ * Works with any provider that exposes the OpenAI Chat Completions and
+ * (optionally) Embeddings API shape:
+ *  - vLLM  (`http://localhost:8000/v1`)
+ *  - LM Studio (`http://localhost:1234/v1`)
+ *  - Together AI (`https://api.together.xyz/v1`)
+ *  - Fireworks (`https://api.fireworks.ai/inference/v1`)
+ *  - Groq (`https://api.groq.com/openai/v1`) — LLM only
+ *  - DeepInfra (`https://api.deepinfra.com/v1/openai`)
+ *  - SiliconFlow (`https://api.siliconflow.cn/v1`)
+ *  - OpenRouter (`https://openrouter.ai/api/v1`)
+ *
+ * Configure via `opendocuments.config.ts`:
+ * ```ts
+ * model: {
+ *   provider: 'openai-compatible',
+ *   apiKey: process.env.MY_API_KEY,
+ *   baseUrl: 'https://api.groq.com/openai/v1',
+ *   llm: 'llama-4-70b-instruct',
+ *   embedding: 'bge-m3',
+ *   embeddingProvider: 'ollama', // groq doesn't embed — fall back to local
+ * }
+ * ```
+ */
+export class OpenAICompatibleModelPlugin implements ModelPlugin {
+  name = '@opendocuments/model-openai-compatible'
+  type = 'model' as const
+  version = '0.1.0'
+  coreVersion = '^0.1.0'
+  capabilities = { llm: true, embedding: true, reranker: false, vision: false }
+
+  private apiKey = ''
+  private baseUrl = ''
+  private llmModel = ''
+  private embeddingModel = ''
+  private extraHeaders: Record<string, string> = {}
+
+  async setup(ctx: PluginContext): Promise<void> {
+    const config = ctx.config as OpenAICompatibleConfig
+    this.apiKey = config.apiKey || process.env.OPENAI_COMPATIBLE_API_KEY || ''
+    this.baseUrl = config.baseUrl || process.env.OPENAI_COMPATIBLE_BASE_URL || ''
+    this.llmModel = config.llmModel || ''
+    this.embeddingModel = config.embeddingModel || ''
+    if (config.extraHeaders) this.extraHeaders = config.extraHeaders
+    if (config.disableEmbedding) {
+      this.capabilities = { ...this.capabilities, embedding: false }
+    }
+    if (!this.baseUrl) {
+      throw new Error(
+        'model-openai-compatible requires a baseUrl (e.g. https://api.groq.com/openai/v1). ' +
+        'Set it in opendocuments.config.ts `model.baseUrl` or OPENAI_COMPATIBLE_BASE_URL env var.',
+      )
+    }
+  }
+
+  private headers(extra: Record<string, string> = {}): Record<string, string> {
+    const h: Record<string, string> = { ...this.extraHeaders, ...extra }
+    if (this.apiKey) h['Authorization'] = `Bearer ${this.apiKey}`
+    return h
+  }
+
+  async healthCheck(): Promise<HealthStatus> {
+    try {
+      const res = await fetchWithTimeout(`${this.baseUrl}/models`, {
+        headers: this.headers(),
+      }, 10000)
+      return {
+        healthy: res.ok,
+        message: res.ok ? `Connected to ${this.baseUrl}` : `HTTP ${res.status}`,
+      }
+    } catch (err) {
+      return { healthy: false, message: (err as Error).message }
+    }
+  }
+
+  async *generate(prompt: string, opts?: GenerateOpts): AsyncIterable<string> {
+    if (!this.llmModel) throw new Error('openai-compatible: llmModel is not configured')
+
+    const messages: { role: string; content: string }[] = []
+    if (opts?.systemPrompt) messages.push({ role: 'system', content: opts.systemPrompt })
+    messages.push({ role: 'user', content: prompt })
+
+    const res = await fetchWithTimeout(`${this.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: this.headers({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({
+        model: this.llmModel,
+        messages,
+        stream: true,
+        temperature: opts?.temperature ?? 0.3,
+        max_tokens: opts?.maxTokens,
+        stop: opts?.stop,
+      }),
+    }, 180000)
+
+    if (!res.ok) throw new Error(`openai-compatible error (${this.baseUrl}): ${res.status}`)
+    if (!res.body) throw new Error('No response body')
+
+    const reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() || ''
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue
+          const data = line.slice(6).trim()
+          if (data === '[DONE]') return
+          try {
+            const parsed = JSON.parse(data)
+            const content = parsed.choices?.[0]?.delta?.content
+            if (content) yield content
+          } catch {
+            // skip malformed chunks
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock()
+    }
+  }
+
+  async embed(texts: string[]): Promise<EmbeddingResult> {
+    if (!this.embeddingModel) {
+      throw new Error('openai-compatible: embeddingModel is not configured')
+    }
+    const res = await fetchWithTimeout(`${this.baseUrl}/embeddings`, {
+      method: 'POST',
+      headers: this.headers({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({
+        model: this.embeddingModel,
+        input: texts,
+      }),
+    }, 30000)
+
+    if (!res.ok) throw new Error(`openai-compatible embed error (${this.baseUrl}): ${res.status}`)
+    const data = (await res.json()) as { data: { embedding: number[] }[] }
+    return { dense: data.data.map((d) => d.embedding) }
+  }
+}
+
+export default OpenAICompatibleModelPlugin

--- a/plugins/model-openai-compatible/tests/openai-compatible.test.ts
+++ b/plugins/model-openai-compatible/tests/openai-compatible.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { OpenAICompatibleModelPlugin } from '../src/index.js'
+
+describe('OpenAICompatibleModelPlugin', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('requires baseUrl during setup', async () => {
+    const p = new OpenAICompatibleModelPlugin()
+    const origEnv = process.env.OPENAI_COMPATIBLE_BASE_URL
+    delete process.env.OPENAI_COMPATIBLE_BASE_URL
+    await expect(
+      p.setup({ config: {}, dataDir: '/tmp', log: console as any } as any),
+    ).rejects.toThrow(/baseUrl/)
+    if (origEnv !== undefined) process.env.OPENAI_COMPATIBLE_BASE_URL = origEnv
+  })
+
+  it('sends requests to the configured baseUrl', async () => {
+    const p = new OpenAICompatibleModelPlugin()
+    await p.setup({
+      config: {
+        apiKey: 'sk-abc',
+        baseUrl: 'https://example.com/v1',
+        llmModel: 'llama-4-70b',
+      },
+      dataDir: '/tmp',
+      log: console as any,
+    } as any)
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      body: new ReadableStream({
+        start(c) { c.enqueue(new TextEncoder().encode('data: [DONE]\n\n')); c.close() },
+      }),
+    }))
+    for await (const _ of p.generate('hi')) { /* drain */ }
+
+    const call = vi.mocked(fetch).mock.calls[0]
+    expect(call[0]).toBe('https://example.com/v1/chat/completions')
+    expect((call[1] as any).headers.Authorization).toBe('Bearer sk-abc')
+  })
+
+  it('merges extra headers into every request', async () => {
+    const p = new OpenAICompatibleModelPlugin()
+    await p.setup({
+      config: {
+        apiKey: 'k',
+        baseUrl: 'https://openrouter.ai/api/v1',
+        llmModel: 'x',
+        extraHeaders: { 'HTTP-Referer': 'https://myapp.com' },
+      },
+      dataDir: '/tmp',
+      log: console as any,
+    } as any)
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      body: new ReadableStream({
+        start(c) { c.enqueue(new TextEncoder().encode('data: [DONE]\n\n')); c.close() },
+      }),
+    }))
+    for await (const _ of p.generate('hi')) { /* drain */ }
+
+    const headers = (vi.mocked(fetch).mock.calls[0][1] as any).headers
+    expect(headers['HTTP-Referer']).toBe('https://myapp.com')
+  })
+
+  it('embed throws if embeddingModel not configured', async () => {
+    const p = new OpenAICompatibleModelPlugin()
+    await p.setup({
+      config: { baseUrl: 'https://example.com/v1', apiKey: 'k' },
+      dataDir: '/tmp',
+      log: console as any,
+    } as any)
+    await expect(p.embed(['a'])).rejects.toThrow(/embeddingModel/)
+  })
+
+  it('disableEmbedding flag turns off embedding capability', async () => {
+    const p = new OpenAICompatibleModelPlugin()
+    await p.setup({
+      config: {
+        baseUrl: 'https://groq-like.example.com/v1',
+        apiKey: 'k',
+        llmModel: 'x',
+        disableEmbedding: true,
+      },
+      dataDir: '/tmp',
+      log: console as any,
+    } as any)
+    expect(p.capabilities.embedding).toBe(false)
+  })
+})

--- a/plugins/model-openai-compatible/tsconfig.json
+++ b/plugins/model-openai-compatible/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["tests/**/*", "dist"]
+}

--- a/plugins/model-openai-compatible/vitest.config.ts
+++ b/plugins/model-openai-compatible/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary

Expands OpenDocuments's model ecosystem from 5 to 8 providers and introduces a first-class CLI for model management so users no longer need to hand-edit `opendocuments.config.ts` or `.env`.

### New model plugins (3)

| Plugin | Models | Embedding | Notes |
|---|---|---|---|
| `model-deepseek` | DeepSeek-V3.2 / R1 / V4 (upcoming) | — | OpenAI-compatible API, 164K context, cheap reasoning |
| `model-mistral` | Small 4 (MoE) / Large 2.1 / Codestral / Pixtral | `mistral-embed` (1024-dim) | Chat + embeddings + vision |
| `model-openai-compatible` | Any OpenAI-compatible endpoint | Optional | vLLM / LM Studio / Together / Fireworks / Groq / DeepInfra / SiliconFlow / OpenRouter; supports `extraHeaders` and `disableEmbedding` |

Gemma 3/4 and other Ollama models continue to work through the existing `model-ollama` plugin (`ollama pull gemma3:27b` + `model.llm` in config).

### New CLI: `opendocuments model` (7 subcommands)

- `model list [--suggestions]` — current config + installed Ollama models (size, params, quantization) + curated catalog of local/cloud options
- `model pull <a> <b> <c>` — batch pull with per-model size estimates, summed disk-headroom check, in-place progress, and a failure summary at the end
- `model install-ollama` — runs the official Ollama install script on macOS/Linux and waits for the daemon (noop if already running; clear fallback for Windows)
- `model set-key <provider>` — password-masked prompt (or `--key` inline), updates existing `.env` line instead of appending, warns if `.env` isn't in `.gitignore`
- `model test` — round-trips the configured LLM + embedder, reports latency / chunks / embedding dimension
- `model switch` — interactive provider swap that rewrites only the `model:` block of the config (preserves everything else)
- `model rm <name>` — delete an Ollama model

### `init` wizard

- Cloud menu adds DeepSeek and Mistral
- Third backend option: **OpenAI-compatible endpoint** with `baseUrl` prompt (vLLM / LM Studio / Groq / Together / Fireworks / OpenRouter)
- API-key validation extended to grok, deepseek, mistral (previously openai / anthropic / google only)
- Secondary embedding provider flow generalized from anthropic-only to any provider without embeddings (deepseek joins anthropic)
- **Ollama auto-install**: offers to run the official install script and waits up to 15s for daemon startup
- Pre-pull disk-space check with per-model size estimates and 1.5GB headroom
- Local model recommendations refreshed for April 2026 (Gemma 3 / Qwen 3.5 / Llama 4 / DeepSeek R1 distilled)
- Progress updates render in place instead of spamming stdio

### `doctor` diagnostics

- Per-provider API ping section for openai, anthropic, google, grok, deepseek, mistral, openai-compatible
- Distinguishes 401/403 (bad key) from network errors and missing env vars, and links to each provider's key-provisioning URL
- Secondary embedding provider is pinged independently
- Ollama model-presence check now only fires for models Ollama actually owns (avoids spurious failures when LLM is cloud + embedder is Ollama)

### Shared utility

`packages/cli/src/utils/ollama.ts` — `isOllamaRunning`, `listOllamaModels`, `pullOllamaModel` with streaming progress, `deleteOllamaModel`, `getAvailableDiskBytes` (via `statfsSync`), `estimateModelSize` (curated hint table), `getOllamaInstallCommand` (platform-aware).

### Server bootstrap

`PROVIDER_MAP` and `EMBEDDING_DIMENSIONS` extended to cover the three new providers. No breaking changes to existing config.

## Test plan

- [x] `npm run build` — 30/30 workspaces build clean
- [x] `npm run typecheck` — all packages pass
- [x] New plugin tests: 14/14 (deepseek 5 + mistral 4 + openai-compatible 5)
- [x] `rewriteModelBlock` helper tests: 4/4 (cloud swap, openai-compatible + baseUrl, round-trip to ollama, missing-block error)
- [x] Smoke-tested `opendocuments model --help`, `model list --suggestions` against real Ollama install
- [ ] Pre-existing CLI `ask.test.ts` RAG timeout failure reproduces on unchanged bootstrap (tracked separately, not caused by this PR)
- [ ] Interactive test of `init` new-provider flow (manual)
- [ ] `doctor` ping against at least one configured cloud provider (manual)

## Out of scope / follow-ups

- Web UI model manager (CLI only for now)
- Ollama-native progress parity with `ollama pull` (we stream the API; it's close but not identical)
- Changeset entries for the three new plugin packages (add when cutting a release)