### PR TITLE
feat: add reStructuredText (.rst) parser plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1143,6 +1143,20 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@turbo/darwin-64": {
+      "version": "2.8.21",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.8.21.tgz",
+      "integrity": "sha512-kfGoM0Iw8ZNZpbds+4IzOe0hjvHldqJwUPRAjXJi3KBxg/QOZL95N893SRoMtf2aJ+jJ3dk32yPkp8rvcIjP9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
     "node_modules/@turbo/darwin-arm64": {
       "version": "2.8.21",
       "cpu": [
@@ -1153,6 +1167,62 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@turbo/linux-64": {
+      "version": "2.8.21",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.8.21.tgz",
+      "integrity": "sha512-uTxlCcXWy5h1fSSymP8XSJ+AudzEHMDV3IDfKX7+DGB8kgJ+SLoTUAH7z4OFA7I/l2sznz0upPdbNNZs91YMag==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/linux-arm64": {
+      "version": "2.8.21",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.8.21.tgz",
+      "integrity": "sha512-cdHIcxNcihHHkCHp0Y4Zb60K4Qz+CK4xw1gb6s/t/9o4SMeMj+hTBCtoW6QpPnl9xPYmxuTou8Zw6+cylTnREg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/windows-64": {
+      "version": "2.8.21",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.8.21.tgz",
+      "integrity": "sha512-/iBj4OzbqEY8CX+eaeKbBTMZv2CLXNrt0692F7HnK7LcyYwyDecaAiSET6ZzL4opT7sbwkKvzAC/fhqT3Quu1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@turbo/windows-arm64": {
+      "version": "2.8.21",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.8.21.tgz",
+      "integrity": "sha512-95tMA/ZbIidJFUUtkmqioQ1gf3n3I1YbRP3ZgVdWTVn2qVbkodcIdGXBKRHHrIbRsLRl99SiHi/L7IxhpZDagQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@types/babel__core": {
@@ -4413,6 +4483,10 @@
       "resolved": "plugins/parser-pptx",
       "link": true
     },
+    "node_modules/opendocuments-parser-rst": {
+      "resolved": "plugins/parser-rst",
+      "link": true
+    },
     "node_modules/opendocuments-parser-xlsx": {
       "resolved": "plugins/parser-xlsx",
       "link": true
@@ -6701,13 +6775,6 @@
         "vitest": "^2.1.0"
       }
     },
-    "plugins/connector-confluence/node_modules/jiti": {
-      "version": "2.6.1",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "plugins/connector-discord": {
       "name": "@opendocuments/connector-discord",
       "version": "0.1.1",
@@ -7006,6 +7073,21 @@
     "plugins/parser-pptx": {
       "name": "opendocuments-parser-pptx",
       "version": "0.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "opendocuments-core": "0.3.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.5.0",
+        "vitest": "^2.1.0"
+      },
+      "peerDependencies": {
+        "opendocuments-core": "^0.3.0"
+      }
+    },
+    "plugins/parser-rst": {
+      "name": "opendocuments-parser-rst",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "opendocuments-core": "0.3.0"

--- a/plugins/parser-rst/CHANGELOG.md
+++ b/plugins/parser-rst/CHANGELOG.md
@@ -1,0 +1,11 @@
+# opendocuments-parser-rst
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release: reStructuredText (`.rst`) parser plugin
+  - Parses headings (underlined and overlined styles) into heading hierarchy
+  - Parses `.. code-block::` and `.. code::` directives with language detection
+  - Parses literal blocks introduced by `::`
+  - Skips non-code directives

--- a/plugins/parser-rst/package.json
+++ b/plugins/parser-rst/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "opendocuments-parser-rst",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "opendocuments-core": "0.3.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "vitest": "^2.1.0"
+  },
+  "peerDependencies": {
+    "opendocuments-core": "^0.3.0"
+  },
+  "license": "MIT",
+  "files": [
+    "dist/**/*"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joungminsung/OpenDocuments.git",
+    "directory": "plugins/parser-rst"
+  }
+}

--- a/plugins/parser-rst/src/index.ts
+++ b/plugins/parser-rst/src/index.ts
@@ -1,0 +1,135 @@
+import type { ParserPlugin, RawDocument, ParsedChunk, PluginContext, HealthStatus } from 'opendocuments-core'
+
+const ADORNMENT_RE = /^([!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])\1+\s*$/
+
+function adornmentChar(line: string): string | null {
+  const m = line.match(ADORNMENT_RE)
+  return m ? m[1] : null
+}
+
+export class RSTParser implements ParserPlugin {
+  name = '@opendocuments/parser-rst'
+  type = 'parser' as const
+  version = '0.1.0'
+  coreVersion = '^0.3.0'
+  supportedTypes = ['.rst']
+
+  async setup(_ctx: PluginContext): Promise<void> {}
+  async healthCheck(): Promise<HealthStatus> { return { healthy: true } }
+
+  async *parse(raw: RawDocument): AsyncIterable<ParsedChunk> {
+    const text = typeof raw.content === 'string' ? raw.content : raw.content.toString('utf-8')
+    if (!text.trim()) return
+
+    const lines = text.split('\n')
+    const adornmentLevels = new Map<string, number>()
+    let nextLevel = 1
+    const headings: string[] = []
+    let i = 0
+
+    const levelFor = (char: string): number => {
+      if (!adornmentLevels.has(char)) adornmentLevels.set(char, nextLevel++)
+      return adornmentLevels.get(char)!
+    }
+
+    const currentHierarchy = (): string[] => headings.filter(Boolean)
+
+    const collectIndentedBlock = (): string => {
+      const baseIndent = lines[i]?.match(/^(\s+)/)?.[1]?.length ?? 4
+      const codeLines: string[] = []
+      while (i < lines.length && (lines[i].trim() === '' || /^\s/.test(lines[i]))) {
+        codeLines.push(lines[i].replace(new RegExp(`^\\s{0,${baseIndent}}`), ''))
+        i++
+      }
+      while (codeLines.length && !codeLines[codeLines.length - 1].trim()) codeLines.pop()
+      return codeLines.join('\n').trim()
+    }
+
+    while (i < lines.length) {
+      const line = lines[i]
+      const trimmed = line.trim()
+
+      if (!trimmed) { i++; continue }
+
+      // Overlined heading: ====, text, ====
+      const overChar = adornmentChar(line)
+      if (overChar && i + 2 < lines.length) {
+        const textLine = lines[i + 1].trim()
+        const underChar = adornmentChar(lines[i + 2])
+        if (textLine && underChar === overChar && lines[i + 2].trim().length >= textLine.length) {
+          const level = levelFor(overChar)
+          headings.length = level - 1
+          headings[level - 1] = textLine
+          i += 3
+          continue
+        }
+      }
+
+      // Underlined heading: text, ====
+      if (!overChar && i + 1 < lines.length) {
+        const underChar = adornmentChar(lines[i + 1])
+        if (underChar && lines[i + 1].trim().length >= trimmed.length) {
+          const level = levelFor(underChar)
+          headings.length = level - 1
+          headings[level - 1] = trimmed
+          i += 2
+          continue
+        }
+      }
+
+      // Code block directive: .. code-block:: lang or .. code:: lang
+      const codeMatch = trimmed.match(/^\.\.\s+code(?:-block)?::\s*(\w*)/)
+      if (codeMatch) {
+        const lang = codeMatch[1] || undefined
+        i++
+        while (i < lines.length && lines[i].match(/^\s+:\w+:/)) i++
+        if (i < lines.length && !lines[i].trim()) i++
+        const code = collectIndentedBlock()
+        if (code) {
+          yield { content: code, chunkType: 'code-ast', language: lang, headingHierarchy: currentHierarchy() }
+        }
+        continue
+      }
+
+      // Other directives: skip body
+      if (trimmed.match(/^\.\.\s+\w/)) {
+        i++
+        while (i < lines.length && (/^\s/.test(lines[i]) || !lines[i].trim())) i++
+        continue
+      }
+
+      // Regular paragraph
+      const paraLines: string[] = []
+      while (i < lines.length && lines[i].trim()) {
+        paraLines.push(lines[i])
+        i++
+      }
+      const lastLine = paraLines[paraLines.length - 1]
+      const endsWithDoubleColon = !!lastLine?.trim().endsWith('::')
+
+      if (endsWithDoubleColon) {
+        if (lastLine.trim() === '::') {
+          paraLines.pop()
+        } else {
+          paraLines[paraLines.length - 1] = lastLine.replace(/::$/, ':')
+        }
+      }
+
+      const para = paraLines.join('\n').trim()
+      if (para) {
+        yield { content: para, chunkType: 'semantic', headingHierarchy: currentHierarchy() }
+      }
+
+      // Literal block following ::
+      if (endsWithDoubleColon) {
+        while (i < lines.length && !lines[i].trim()) i++
+        const code = collectIndentedBlock()
+        if (code) {
+          yield { content: code, chunkType: 'code-ast', headingHierarchy: currentHierarchy() }
+        }
+      }
+    }
+  }
+}
+
+export default RSTParser

--- a/plugins/parser-rst/tests/rst.test.ts
+++ b/plugins/parser-rst/tests/rst.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { RSTParser } from '../src/index.js'
+import type { ParsedChunk } from 'opendocuments-core'
+
+async function collect(parser: RSTParser, content: string): Promise<ParsedChunk[]> {
+  const chunks: ParsedChunk[] = []
+  for await (const chunk of parser.parse({ sourceId: 'test', title: 'test.rst', content })) {
+    chunks.push(chunk)
+  }
+  return chunks
+}
+
+describe('RSTParser', () => {
+  let parser: RSTParser
+
+  beforeEach(async () => {
+    parser = new RSTParser()
+    await parser.setup({ config: {}, dataDir: '/tmp', log: console as any })
+  })
+
+  it('has correct metadata', () => {
+    expect(parser.name).toBe('@opendocuments/parser-rst')
+    expect(parser.supportedTypes).toEqual(['.rst'])
+    expect(parser.type).toBe('parser')
+  })
+
+  it('reports healthy', async () => {
+    const status = await parser.healthCheck()
+    expect(status.healthy).toBe(true)
+  })
+
+  it('returns no chunks for empty input', async () => {
+    const chunks = await collect(parser, '')
+    expect(chunks).toHaveLength(0)
+
+    const blank = await collect(parser, '   \n\n  \n')
+    expect(blank).toHaveLength(0)
+  })
+
+  it('extracts underlined headings and builds heading hierarchy', async () => {
+    const rst = `
+Introduction
+============
+
+This is an intro paragraph.
+
+Getting Started
+---------------
+
+Install the package first.
+`.trim()
+
+    const chunks = await collect(parser, rst)
+    const intro = chunks.find(c => c.content.includes('intro paragraph'))
+    const install = chunks.find(c => c.content.includes('Install'))
+
+    expect(intro).toBeDefined()
+    expect(intro!.headingHierarchy).toEqual(['Introduction'])
+
+    expect(install).toBeDefined()
+    expect(install!.headingHierarchy).toEqual(['Introduction', 'Getting Started'])
+  })
+
+  it('extracts overlined headings', async () => {
+    const rst = `
+==========
+Main Title
+==========
+
+Some content here.
+`.trim()
+
+    const chunks = await collect(parser, rst)
+    expect(chunks[0].headingHierarchy).toEqual(['Main Title'])
+    expect(chunks[0].content).toBe('Some content here.')
+  })
+
+  it('parses code-block directives with language tag', async () => {
+    const rst = `
+Usage
+-----
+
+.. code-block:: python
+
+    def hello():
+        return "world"
+`.trim()
+
+    const chunks = await collect(parser, rst)
+    const code = chunks.find(c => c.chunkType === 'code-ast')
+    expect(code).toBeDefined()
+    expect(code!.language).toBe('python')
+    expect(code!.content).toContain('def hello()')
+    expect(code!.headingHierarchy).toEqual(['Usage'])
+  })
+
+  it('parses .. code:: directive (alternative syntax)', async () => {
+    const rst = `
+.. code:: typescript
+
+    const x: number = 42
+`.trim()
+
+    const chunks = await collect(parser, rst)
+    const code = chunks.find(c => c.chunkType === 'code-ast')
+    expect(code).toBeDefined()
+    expect(code!.language).toBe('typescript')
+    expect(code!.content).toContain('const x')
+  })
+
+  it('parses literal blocks introduced by ::', async () => {
+    const rst = `
+Example::
+
+    $ npm install opendocuments
+    $ opendocuments start
+`.trim()
+
+    const chunks = await collect(parser, rst)
+    const para = chunks.find(c => c.chunkType === 'semantic')
+    const code = chunks.find(c => c.chunkType === 'code-ast')
+
+    expect(para).toBeDefined()
+    expect(para!.content).toMatch(/Example/)
+    expect(code).toBeDefined()
+    expect(code!.content).toContain('npm install')
+  })
+
+  it('handles standalone :: paragraph separator before literal block', async () => {
+    const rst = `
+Description
+
+::
+
+    some literal content
+`.trim()
+
+    const chunks = await collect(parser, rst)
+    const code = chunks.find(c => c.chunkType === 'code-ast')
+    expect(code).toBeDefined()
+    expect(code!.content).toContain('some literal content')
+  })
+
+  it('resets heading hierarchy when same-level heading appears', async () => {
+    const rst = `
+Chapter One
+===========
+
+Intro text.
+
+Chapter Two
+===========
+
+More text.
+`.trim()
+
+    const chunks = await collect(parser, rst)
+    const intro = chunks.find(c => c.content.includes('Intro'))
+    const more = chunks.find(c => c.content.includes('More'))
+
+    expect(intro!.headingHierarchy).toEqual(['Chapter One'])
+    expect(more!.headingHierarchy).toEqual(['Chapter Two'])
+  })
+
+  it('skips non-code directives without emitting their body as content', async () => {
+    const rst = `
+Title
+=====
+
+.. note::
+
+    This is a note directive body.
+
+Real content here.
+`.trim()
+
+    const chunks = await collect(parser, rst)
+    const hasNote = chunks.some(c => c.content.includes('This is a note directive body'))
+    const hasContent = chunks.some(c => c.content.includes('Real content'))
+    expect(hasNote).toBe(false)
+    expect(hasContent).toBe(true)
+  })
+})

--- a/plugins/parser-rst/tsconfig.json
+++ b/plugins/parser-rst/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["tests/**/*", "dist"]
+}

--- a/plugins/parser-rst/vitest.config.ts
+++ b/plugins/parser-rst/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
Closes #1

## Summary

- Implements `ParserPlugin` interface from `opendocuments-core` for `.rst` files
- Parses **headings** — both underlined (`text\n====`) and overlined (`====\ntext\n====`) styles, tracking full heading hierarchy across nesting levels
- Parses **code blocks** via `.. code-block:: lang` and `.. code:: lang` directives with language detection
- Parses **literal blocks** introduced by `::` at the end of a paragraph
- Skips non-code directives (notes, warnings, images, etc.) without emitting their body as content

## Test plan

- [x] Metadata validation (name, type, supportedTypes)
- [x] Health check returns healthy
- [x] Empty / whitespace-only input yields no chunks
- [x] Underlined headings build correct hierarchy
- [x] Overlined headings parsed correctly
- [x] `.. code-block:: lang` directive yields `code-ast` chunk with language
- [x] `.. code:: lang` alternative directive syntax
- [x] Literal blocks (`::`) yield `code-ast` chunk
- [x] Standalone `::` paragraph separator
- [x] Same-level heading resets hierarchy correctly
- [x] Non-code directive bodies are skipped (11 tests total, all passing)