### PR TITLE
Optimize AEO and SEO metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <h1 align="center">OpenDocuments</h1>
-  <p align="center"><strong>Open source RAG tool for AI document search — connect GitHub, Notion, Google Drive and ask questions with cited answers</strong></p>
+  <p align="center"><strong>Self-hosted RAG platform for AI document search across GitHub, Notion, Google Drive, Confluence, S3, local files, and web sources</strong></p>
 </p>
 
 <p align="center">
@@ -19,7 +19,27 @@
 
 ---
 
-## The Problem: Scattered Knowledge, No AI Search
+## What is OpenDocuments?
+
+**OpenDocuments is an open source, self-hosted RAG (Retrieval-Augmented Generation) platform that turns scattered company documents into an AI-searchable knowledge base.** It connects to sources like GitHub, Notion, Google Drive, Confluence, S3, Swagger/OpenAPI, local files, and web pages, indexes them with hybrid vector + keyword search, and answers natural-language questions with cited sources.
+
+Use OpenDocuments when you want:
+
+- A **self-hosted alternative to enterprise AI search** and proprietary knowledge-base search tools
+- **AI document search with citations** for engineering docs, product specs, policies, spreadsheets, API docs, and meeting notes
+- A **local-first RAG stack** that can run with Ollama so sensitive documents stay on your own infrastructure
+- A **knowledge base for AI coding assistants** through MCP, including Claude Code, Cursor, Windsurf, and other MCP clients
+- A **TypeScript-first RAG platform** with a CLI, Web UI, HTTP API, SDK, plugin system, and embeddable widget
+
+```bash
+npm install -g opendocuments
+opendocuments init
+opendocuments start
+```
+
+Open `http://localhost:3000`, index your documents, and ask questions with source citations.
+
+## Why OpenDocuments?
 
 Your team's knowledge is trapped in silos:
 
@@ -30,21 +50,37 @@ Your team's knowledge is trapped in silos:
 - **Meeting notes** rot in Confluence spaces
 - **Onboarding guides** are buried in `.docx` files on S3
 
-When someone asks _"How does our auth system work?"_ or _"What was the Q3 budget for the AI team?"_, they spend 15 minutes hunting through 5 different tools. And they still might not find the answer.
+When someone asks _"How does our auth system work?"_ or _"What was the Q3 budget for the AI team?"_, they spend 15 minutes hunting through five different tools. OpenDocuments centralizes that search without forcing all of your content into a hosted vendor.
 
-## The Solution: Self-Hosted AI Document Search
+## How OpenDocuments Answers Questions
 
-OpenDocuments **connects to all your document sources**, **indexes everything into a unified search engine**, and **answers questions in natural language** -- with source citations so you know exactly where the answer came from.
+OpenDocuments **connects to your document sources**, **parses and chunks each document**, **stores metadata in SQLite and vectors in LanceDB**, then **retrieves, reranks, and generates grounded answers**. Every answer can include source citations, confidence scores, and links back to the underlying documents.
 
-```bash
-npm install -g opendocuments
-opendocuments init
-opendocuments start
-```
+In short: **OpenDocuments is a private AI search engine for your organization's documents.**
 
-Open `http://localhost:3000`, and ask away.
+## Key Features
 
-> **OpenDocuments** is a free, open source alternative to proprietary enterprise AI search tools. It's a self-hosted RAG (Retrieval-Augmented Generation) platform that runs on your own infrastructure.
+| Feature | What it means |
+|---------|---------------|
+| **Self-hosted RAG** | Run the full document search stack on your own infrastructure |
+| **Cited AI answers** | Ask natural-language questions and see exactly which documents support the answer |
+| **Hybrid retrieval** | Combine vector search, FTS5 keyword search, reranking, HyDE, multi-query retrieval, and parent-document recall |
+| **Broad source coverage** | Index GitHub, Notion, Google Drive, Confluence, S3/GCS, Swagger/OpenAPI, web pages, web search, uploads, and local files |
+| **Many file formats** | Parse Markdown, PDF, DOCX, XLSX, CSV, HTML, Jupyter notebooks, email, code, PPTX, JSON, YAML, TOML, and more |
+| **Local or cloud models** | Use Ollama locally or cloud providers such as OpenAI, Anthropic, Google, and xAI |
+| **MCP server** | Let Claude Code, Cursor, Windsurf, and other MCP clients search your internal knowledge base |
+| **Team mode** | Add API keys, roles, rate limits, PII redaction, audit logs, alerts, OAuth SSO, and workspace isolation |
+| **Extensible plugins** | Build custom parsers, connectors, model providers, and middleware in TypeScript |
+
+## OpenDocuments vs Alternatives
+
+| If you are comparing... | Choose OpenDocuments when you need... |
+|-------------------------|----------------------------------------|
+| **OpenDocuments vs hosted enterprise search** | A self-hosted, open source AI search platform with control over infrastructure and data flow |
+| **OpenDocuments vs a vector database** | A complete RAG application layer: connectors, parsers, chunking, retrieval, chat, citations, auth, CLI, Web UI, and MCP |
+| **OpenDocuments vs a chatbot wrapper** | Source-grounded answers over your real document corpus, not a generic chat UI |
+| **OpenDocuments vs building RAG from scratch** | A TypeScript monorepo with batteries included, while still keeping plugin-level extensibility |
+| **OpenDocuments vs local-only scripts** | A production-oriented system with team mode, API access, syncable connectors, backups, and admin tooling |
 
 ### Recent Improvements
 - **RAG accuracy overhaul**: Structure-preserving chunking, contextual prefixes, HyDE + multi-query retrieval, parent-document recall, proposition augmentation, reranking, and adaptive context fitting
@@ -122,6 +158,8 @@ docker compose --profile with-ollama up -d
 
 ## Quick Start
 
+This is the fastest way to run a local AI document search engine with the OpenDocuments CLI.
+
 ### 1. Install
 
 ```bash
@@ -173,6 +211,8 @@ opendocuments ask "What's our deployment process?"
 ---
 
 ## How It Works
+
+OpenDocuments uses a standard RAG architecture with practical production pieces around it: source connectors, format parsers, chunking, embeddings, metadata storage, vector storage, retrieval profiles, answer generation, citations, and security controls.
 
 ```
     Your Documents                    OpenDocuments                     You
@@ -587,6 +627,46 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for conventions, test patterns, and plugi
 | [TypeScript SDK](docs-site/sdk/guide.md) | Programmatic API client |
 | [Security Policy](SECURITY.md) | Vulnerability reporting |
 | [Contributing](CONTRIBUTING.md) | Development setup, conventions, plugin guide |
+
+---
+
+## Frequently Asked Questions
+
+### What is OpenDocuments used for?
+
+OpenDocuments is used to build a private AI search engine over company documents. Teams use it to ask questions across GitHub repositories, Notion pages, Google Drive files, Confluence spaces, S3 buckets, API specs, local files, and web pages, then receive answers with citations.
+
+### Is OpenDocuments open source?
+
+Yes. OpenDocuments is open source and released under the [MIT License](LICENSE).
+
+### Is OpenDocuments self-hosted?
+
+Yes. OpenDocuments is designed for self-hosted deployment. You can run it locally during development, deploy it with Docker, or host it on your own infrastructure.
+
+### Can OpenDocuments run without sending data to a cloud LLM?
+
+Yes. When configured with Ollama and local embedding models, OpenDocuments can run the LLM, embeddings, vector search, metadata database, Web UI, CLI, and MCP server on your own infrastructure.
+
+### What data sources does OpenDocuments support?
+
+OpenDocuments supports local files, file uploads, GitHub, Notion, Google Drive, Amazon S3, Google Cloud Storage, Confluence, Swagger/OpenAPI specs, registered web pages, and Tavily-backed web search.
+
+### What file formats can OpenDocuments index?
+
+OpenDocuments can index Markdown, plain text, PDF, DOCX, XLSX, CSV, HTML, Jupyter notebooks, email, source code, PPTX, JSON, YAML, TOML, and other supported plugin formats.
+
+### Does OpenDocuments work with Claude Code or Cursor?
+
+Yes. OpenDocuments includes an MCP server, so MCP-compatible AI tools such as Claude Code, Cursor, Windsurf, and similar clients can search your indexed document corpus while assisting with development.
+
+### What makes OpenDocuments different from a vector database?
+
+A vector database stores embeddings. OpenDocuments provides the surrounding RAG platform: connectors, parsers, document chunking, hybrid retrieval, reranking, answer generation, citations, Web UI, CLI, HTTP API, SDK, MCP server, authentication, and plugins.
+
+### What makes OpenDocuments different from hosted enterprise search?
+
+OpenDocuments is open source and self-hosted. It is built for teams that want AI document search, source citations, plugin extensibility, and control over where their documents, embeddings, metadata, and model calls run.
 
 ---
 

--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -2,25 +2,50 @@ import { defineConfig } from 'vitepress'
 
 export default defineConfig({
   title: 'OpenDocuments',
-  description: 'Open source self-hosted RAG tool for AI document search — connect GitHub, Notion, Google Drive, and more. Ask questions in natural language with source citations.',
+  description: 'Open source self-hosted RAG platform for AI document search across GitHub, Notion, Google Drive, Confluence, S3, local files, and web sources. Ask questions with source citations.',
   lang: 'en-US',
   base: '/OpenDocuments/',
   ignoreDeadLinks: [/localhost/],
 
   head: [
-    ['meta', { name: 'keywords', content: 'rag tool, ai document search, self-hosted knowledge base, open source rag, retrieval augmented generation, llm document search, ollama rag, vector search, ai knowledge management, document qa, enterprise search, mcp server' }],
-    ['meta', { property: 'og:title', content: 'OpenDocuments — Open Source RAG Tool for AI Document Search' }],
-    ['meta', { property: 'og:description', content: 'Self-hosted RAG platform that connects scattered documents (GitHub, Notion, Drive, Confluence) and answers questions with AI. Supports Ollama, OpenAI, Claude, Gemini.' }],
+    ['meta', { name: 'keywords', content: 'self-hosted rag, ai document search, open source rag, retrieval augmented generation, knowledge base, llm document search, ollama rag, vector search, semantic search, document qa, enterprise search alternative, mcp server, github search, notion search, google drive search' }],
+    ['meta', { property: 'og:title', content: 'OpenDocuments - Self-Hosted RAG Platform for AI Document Search' }],
+    ['meta', { property: 'og:description', content: 'Open source RAG platform that connects GitHub, Notion, Google Drive, Confluence, S3, local files, and web sources, then answers questions with citations.' }],
     ['meta', { property: 'og:type', content: 'website' }],
-    ['meta', { property: 'og:url', content: 'https://opendocuments.dev' }],
+    ['meta', { property: 'og:url', content: 'https://joungminsung.github.io/OpenDocuments/' }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
-    ['meta', { name: 'twitter:title', content: 'OpenDocuments — Open Source RAG Tool' }],
-    ['meta', { name: 'twitter:description', content: 'Self-hosted AI document search. Connect GitHub, Notion, Drive. Ask questions, get cited answers.' }],
-    ['link', { rel: 'canonical', href: 'https://opendocuments.dev' }],
+    ['meta', { name: 'twitter:title', content: 'OpenDocuments - Self-Hosted RAG Platform' }],
+    ['meta', { name: 'twitter:description', content: 'Self-hosted AI document search across GitHub, Notion, Google Drive, local files, and web sources.' }],
+    ['link', { rel: 'canonical', href: 'https://joungminsung.github.io/OpenDocuments/' }],
+    ['script', { type: 'application/ld+json' }, JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'SoftwareApplication',
+      name: 'OpenDocuments',
+      applicationCategory: 'DeveloperApplication',
+      operatingSystem: 'macOS, Linux, Windows',
+      description: 'Open source self-hosted RAG platform for AI document search with source citations.',
+      softwareVersion: '0.3.0',
+      license: 'https://github.com/joungminsung/OpenDocuments/blob/main/LICENSE',
+      codeRepository: 'https://github.com/joungminsung/OpenDocuments',
+      programmingLanguage: 'TypeScript',
+      offers: {
+        '@type': 'Offer',
+        price: '0',
+        priceCurrency: 'USD',
+      },
+      featureList: [
+        'Self-hosted retrieval augmented generation',
+        'AI document search with source citations',
+        'GitHub, Notion, Google Drive, Confluence, S3, local file, and web connectors',
+        'Ollama, OpenAI, Anthropic, Google, and xAI model providers',
+        'MCP server for AI coding assistants',
+        'TypeScript SDK, CLI, Web UI, and HTTP API',
+      ],
+    })],
   ],
 
   sitemap: {
-    hostname: 'https://opendocuments.dev',
+    hostname: 'https://joungminsung.github.io/OpenDocuments/',
   },
 
   themeConfig: {
@@ -29,10 +54,15 @@ export default defineConfig({
       { text: 'API', link: '/api/' },
       { text: 'Plugins', link: '/plugins/' },
       { text: 'SDK', link: '/sdk/guide' },
+      { text: 'GitHub', link: 'https://github.com/joungminsung/OpenDocuments' },
     ],
     sidebar: [
       { text: 'Getting Started', items: [
         { text: 'Quick Start', link: '/guide/' },
+        { text: 'What is OpenDocuments?', link: '/guide/what-is-opendocuments' },
+        { text: 'Comparisons', link: '/guide/comparisons' },
+        { text: 'Self-Hosted RAG with Ollama', link: '/guide/self-hosted-rag-ollama' },
+        { text: 'MCP Knowledge Base', link: '/guide/mcp-knowledge-base' },
         { text: 'Architecture', link: '/guide/architecture' },
         { text: 'Configuration', link: '/guide/configuration' },
         { text: 'Deployment', link: '/guide/deployment' },

--- a/docs-site/guide/comparisons.md
+++ b/docs-site/guide/comparisons.md
@@ -1,0 +1,74 @@
+---
+title: OpenDocuments Comparisons
+description: Compare OpenDocuments with vector databases, hosted enterprise search, chatbot wrappers, local RAG scripts, and building a RAG platform from scratch.
+head:
+  - - meta
+    - name: keywords
+      content: opendocuments vs vector database, opendocuments vs enterprise search, open source enterprise search alternative, rag platform comparison, self-hosted ai search
+---
+
+# OpenDocuments Comparisons
+
+OpenDocuments is best understood as a complete self-hosted RAG platform, not only a vector store, chatbot, or connector library. It includes the pieces needed to ingest documents, retrieve relevant context, answer questions, cite sources, and expose the system through a Web UI, CLI, HTTP API, SDK, and MCP server.
+
+## OpenDocuments vs a vector database
+
+| Question | Vector database | OpenDocuments |
+|----------|-----------------|---------------|
+| Stores embeddings | Yes | Yes, through LanceDB |
+| Parses documents | Usually no | Yes, through parser plugins |
+| Connects to document sources | Usually no | Yes, through connector plugins |
+| Provides RAG profiles | No | Yes: fast, balanced, precise |
+| Generates cited answers | No | Yes |
+| Has Web UI and CLI | Usually no | Yes |
+| Has MCP server | No | Yes |
+| Handles auth and team mode | Usually separate | Built in |
+
+Use a vector database when you only need storage and similarity search. Use OpenDocuments when you need the full RAG application layer around document ingestion, retrieval, generation, citations, and operations.
+
+## OpenDocuments vs hosted enterprise search
+
+Hosted enterprise search tools are convenient, but they can create vendor lock-in and data-flow constraints. OpenDocuments is open source and self-hosted, so teams can choose where documents, embeddings, metadata, and model calls run.
+
+| Need | OpenDocuments fit |
+|------|-------------------|
+| Keep documents on your infrastructure | Strong |
+| Use local LLMs through Ollama | Strong |
+| Customize parsers and connectors | Strong |
+| Avoid per-seat SaaS pricing | Strong |
+| Use a managed vendor with minimal ops | Hosted tools may fit better |
+
+## OpenDocuments vs a chatbot wrapper
+
+A chatbot wrapper usually provides a chat interface over one model or a small set of files. OpenDocuments focuses on source-grounded document search across many repositories, formats, and systems.
+
+Choose OpenDocuments when you need:
+
+- Citations and confidence signals
+- Source connectors for GitHub, Notion, Google Drive, Confluence, S3, and web pages
+- Hybrid vector and keyword search
+- RAG profiles for speed versus precision
+- Admin, audit, workspace, and auth controls
+- MCP access for AI coding assistants
+
+## OpenDocuments vs building RAG from scratch
+
+Building RAG from scratch gives complete control, but it also means rebuilding parsers, connectors, chunking, embeddings, storage, retrieval, reranking, citations, sync, auth, UI, CLI, and evaluation workflows.
+
+OpenDocuments is a better starting point when you want a working TypeScript RAG platform with plugin-level extensibility.
+
+## OpenDocuments vs local RAG scripts
+
+Local scripts are good for experiments. OpenDocuments is better when you need a system that can keep growing:
+
+- Document sync and file watching
+- Multiple source connectors
+- Multiple file parsers
+- Web UI, CLI, API, SDK, and MCP access
+- Team mode and workspace isolation
+- Backup and restore
+- Plugin development workflow
+
+## Short answer
+
+OpenDocuments is for teams that want a complete, self-hosted, open source AI document search platform. It sits above a vector database and below a fully managed enterprise search vendor: more complete than infrastructure primitives, more controllable than hosted search.

--- a/docs-site/guide/mcp-knowledge-base.md
+++ b/docs-site/guide/mcp-knowledge-base.md
@@ -1,0 +1,71 @@
+---
+title: MCP Knowledge Base for Claude Code and Cursor
+description: Use OpenDocuments as an MCP knowledge base so Claude Code, Cursor, Windsurf, and other MCP clients can search internal documents while helping with development.
+head:
+  - - meta
+    - name: keywords
+      content: mcp knowledge base, claude code document search, cursor knowledge base, mcp server rag, ai coding assistant internal docs
+---
+
+# MCP Knowledge Base for Claude Code and Cursor
+
+OpenDocuments includes an MCP server so AI coding assistants can search your indexed document corpus. This turns GitHub docs, Notion pages, Google Drive files, Confluence pages, API specs, and local files into a searchable knowledge base for development workflows.
+
+## Why use OpenDocuments with MCP?
+
+AI coding assistants are most useful when they can see the context behind a codebase: architecture notes, runbooks, API contracts, design docs, incidents, release notes, and decisions. OpenDocuments indexes that context and exposes it through MCP tools.
+
+Use this setup when you want an assistant to answer questions like:
+
+- How does authentication work in this service?
+- Which API endpoint handles token refresh?
+- What does the migration guide say about v3?
+- Where is the deployment checklist?
+- What did the product spec decide about billing states?
+
+## Start the MCP server
+
+```bash
+opendocuments start --mcp-only
+```
+
+Then configure your MCP-compatible client to call the OpenDocuments command:
+
+```json
+{
+  "mcpServers": {
+    "opendocuments": {
+      "command": "opendocuments",
+      "args": ["start", "--mcp-only"]
+    }
+  }
+}
+```
+
+## What can the MCP server do?
+
+The MCP server lets compatible clients:
+
+- Search indexed organizational documents
+- Ask natural-language questions over the document corpus
+- Inspect document status and connector health
+- Index newly created files
+- Query useful configuration and admin context
+
+## Best documents to index for AI coding
+
+Start with documents that explain intent and operating context:
+
+- Architecture docs
+- API specs
+- Runbooks
+- ADRs and technical decisions
+- Onboarding guides
+- Release notes
+- Incident reviews
+- Product specs
+- Database and migration notes
+
+## Short answer
+
+OpenDocuments can act as the retrieval layer for Claude Code, Cursor, Windsurf, and other MCP clients. It gives AI coding assistants access to source-grounded internal knowledge instead of relying only on the files open in an editor.

--- a/docs-site/guide/self-hosted-rag-ollama.md
+++ b/docs-site/guide/self-hosted-rag-ollama.md
@@ -1,0 +1,63 @@
+---
+title: Self-Hosted RAG with Ollama
+description: Run OpenDocuments as a local-first RAG platform with Ollama, local embeddings, SQLite metadata, LanceDB vector search, Web UI, CLI, API, SDK, and MCP server.
+head:
+  - - meta
+    - name: keywords
+      content: self-hosted rag with ollama, local rag, private document qa, ollama document search, local ai knowledge base, open source rag ollama
+---
+
+# Self-Hosted RAG with Ollama
+
+OpenDocuments can run as a local-first RAG stack with Ollama. This lets you index private documents, search them with local embeddings, and answer questions without requiring a cloud LLM.
+
+## Local RAG architecture
+
+When configured for local models, OpenDocuments can run these pieces on your own machine or infrastructure:
+
+| Layer | Local option |
+|-------|--------------|
+| Chat model | Ollama |
+| Embeddings | BGE-M3 or nomic-embed-text through Ollama |
+| Metadata | SQLite |
+| Vector search | LanceDB |
+| Web UI | Built-in OpenDocuments server |
+| CLI | `opendocuments` |
+| API | Hono HTTP server |
+| AI assistant integration | MCP server |
+
+## Quick start
+
+```bash
+npm install -g opendocuments
+opendocuments init
+opendocuments start
+```
+
+The init wizard detects local hardware, checks Ollama availability, recommends a model, and can offer to pull missing models.
+
+## When should you use local models?
+
+Use Ollama with OpenDocuments when:
+
+- Documents contain sensitive internal knowledge
+- You need development or demo environments with no cloud model dependency
+- You want predictable local experimentation costs
+- You need control over where embeddings and model prompts are processed
+- You are building a private AI knowledge base for engineering, product, operations, or support teams
+
+Cloud models can still be useful for higher answer quality, larger context windows, and managed inference. OpenDocuments supports both local and cloud model providers, so teams can choose per environment.
+
+## Recommended local model paths
+
+| Hardware | LLM direction | Embedding direction |
+|----------|---------------|---------------------|
+| 32GB+ RAM, GPU | Larger Ollama models | BGE-M3 |
+| 16GB RAM | Mid-size Ollama models | BGE-M3 |
+| 8GB RAM | Compact Ollama models | nomic-embed-text |
+
+Run `opendocuments doctor` if models are unavailable or the Web UI shows degraded mode warnings.
+
+## Short answer
+
+OpenDocuments plus Ollama is a practical way to run private document Q&A locally: documents are parsed and indexed by OpenDocuments, embeddings and answers can be generated locally, and users interact through the Web UI, CLI, API, SDK, or MCP server.

--- a/docs-site/guide/what-is-opendocuments.md
+++ b/docs-site/guide/what-is-opendocuments.md
@@ -1,0 +1,70 @@
+---
+title: What is OpenDocuments?
+description: OpenDocuments is an open source self-hosted RAG platform for AI document search with source citations across GitHub, Notion, Google Drive, Confluence, S3, local files, and web sources.
+head:
+  - - meta
+    - name: keywords
+      content: what is opendocuments, self-hosted rag platform, ai document search, open source rag, document question answering, cited ai answers
+  - - script
+    - type: application/ld+json
+    - '{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is OpenDocuments?","acceptedAnswer":{"@type":"Answer","text":"OpenDocuments is an open source self-hosted RAG platform that indexes documents from sources such as GitHub, Notion, Google Drive, Confluence, S3, local files, and web pages, then answers natural-language questions with source citations."}},{"@type":"Question","name":"What is OpenDocuments used for?","acceptedAnswer":{"@type":"Answer","text":"OpenDocuments is used to build a private AI search engine over organizational documents, engineering docs, product specs, policies, spreadsheets, API documentation, and knowledge bases."}},{"@type":"Question","name":"Can OpenDocuments run locally?","acceptedAnswer":{"@type":"Answer","text":"Yes. OpenDocuments can run locally with Ollama for LLM and embedding models, SQLite for metadata, LanceDB for vector search, and the built-in Web UI, CLI, HTTP API, SDK, and MCP server."}}]}'
+---
+
+# What is OpenDocuments?
+
+**OpenDocuments is an open source, self-hosted RAG platform for AI document search.** It connects to scattered documents, indexes them, and answers natural-language questions with source citations.
+
+OpenDocuments is designed for teams that want a private knowledge base search system without sending every document to a hosted enterprise search vendor. It can run locally with Ollama or connect to cloud model providers such as OpenAI, Anthropic, Google, and xAI.
+
+## What problem does OpenDocuments solve?
+
+Teams often store knowledge across many tools:
+
+- GitHub repositories and wikis
+- Notion pages and databases
+- Google Drive files
+- Confluence spaces
+- S3 or Google Cloud Storage buckets
+- Swagger and OpenAPI specs
+- Local Markdown, PDF, DOCX, XLSX, CSV, PPTX, code, and email files
+- Internal or public web pages
+
+OpenDocuments gives those documents one AI-searchable layer. Users can ask questions like "How does authentication work?", "What changed in the v3 product spec?", or "What is our remote work policy?" and get grounded answers with source references.
+
+## How does OpenDocuments work?
+
+OpenDocuments follows a production RAG flow:
+
+1. Connect to document sources.
+2. Parse files and preserve useful structure.
+3. Chunk documents for retrieval.
+4. Generate embeddings.
+5. Store metadata in SQLite and vectors in LanceDB.
+6. Search with hybrid vector and keyword retrieval.
+7. Rerank and expand results based on the selected RAG profile.
+8. Generate an answer with citations and confidence signals.
+
+## Who is OpenDocuments for?
+
+OpenDocuments is useful for:
+
+- Engineering teams that need AI search over code, API docs, runbooks, and architecture notes
+- Product and operations teams that need answers from specs, spreadsheets, policies, and meeting notes
+- AI-assisted development teams that want Claude Code, Cursor, Windsurf, or another MCP client to search internal knowledge
+- Organizations that prefer self-hosted infrastructure and local model options
+- Developers building custom RAG workflows in TypeScript
+
+## What does OpenDocuments include?
+
+OpenDocuments includes:
+
+- Web UI for chat, documents, connectors, plugins, settings, and admin views
+- CLI for indexing, asking, searching, diagnostics, auth, backup, and automation
+- HTTP API and TypeScript SDK
+- MCP server for AI coding assistants
+- Plugin system for parsers, connectors, model providers, and middleware
+- Team mode with API keys, roles, rate limits, PII redaction, audit logs, security alerts, OAuth SSO, and workspace isolation
+
+## Short answer
+
+OpenDocuments is a private AI search engine for your organization's documents. It is best described as a self-hosted RAG platform, an open source enterprise search alternative, and a knowledge base for AI coding assistants.

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -1,16 +1,21 @@
 ---
 layout: home
+title: Self-Hosted RAG Platform for AI Document Search
+description: OpenDocuments is an open source self-hosted RAG platform for AI document search across GitHub, Notion, Google Drive, Confluence, S3, local files, and web sources.
 hero:
   name: OpenDocuments
-  text: Open Source RAG Tool
-  tagline: Self-hosted AI document search — connect your scattered docs and ask questions with source citations
+  text: Self-Hosted RAG Platform
+  tagline: AI document search across GitHub, Notion, Google Drive, Confluence, S3, local files, and web sources with source citations
   actions:
     - theme: brand
       text: Get Started
       link: /guide/
     - theme: alt
-      text: GitHub
-      link: https://github.com/joungminsung/OpenDocuments
+      text: What is OpenDocuments?
+      link: /guide/what-is-opendocuments
+    - theme: alt
+      text: Compare Options
+      link: /guide/comparisons
 features:
   - icon:
       src: /icons/search.svg
@@ -40,9 +45,9 @@ features:
 
 ## What is OpenDocuments?
 
-OpenDocuments is an **open source RAG (Retrieval-Augmented Generation) tool** that connects your scattered organizational documents and lets you **search and ask questions using AI** — with source citations so you know exactly where the answer came from.
+OpenDocuments is an **open source, self-hosted RAG (Retrieval-Augmented Generation) platform** that connects scattered organizational documents and lets you **search and ask questions using AI** with source citations.
 
-Unlike cloud-only solutions, OpenDocuments runs **entirely on your own infrastructure** with local LLMs via Ollama. Your data never leaves your network.
+Unlike cloud-only solutions, OpenDocuments can run **entirely on your own infrastructure** with local LLMs via Ollama. Your data can stay inside your network.
 
 ### Why OpenDocuments?
 
@@ -56,6 +61,14 @@ Unlike cloud-only solutions, OpenDocuments runs **entirely on your own infrastru
 | **AI models** | Any model (Ollama, OpenAI, Claude, Gemini) | Locked to one provider |
 | **Korean support** | Built-in cross-lingual search | Usually English-only |
 
+### Popular searches OpenDocuments answers
+
+- What is the best open source RAG platform for internal documents?
+- How do I build self-hosted AI document search with citations?
+- How can Claude Code or Cursor search our company knowledge base?
+- What is the difference between a RAG platform and a vector database?
+- Can I run private document Q&A with Ollama?
+
 ### Quick Install
 
 ```bash
@@ -65,3 +78,10 @@ opendocuments start   # Opens Web UI at localhost:3000
 ```
 
 Three commands. Under 5 minutes. [Get started →](/guide/)
+
+### Learn more
+
+- [What is OpenDocuments?](/guide/what-is-opendocuments)
+- [OpenDocuments comparisons](/guide/comparisons)
+- [Self-hosted RAG with Ollama](/guide/self-hosted-rag-ollama)
+- [MCP knowledge base for Claude Code and Cursor](/guide/mcp-knowledge-base)

--- a/docs-site/public/llms-full.txt
+++ b/docs-site/public/llms-full.txt
@@ -1,0 +1,99 @@
+# OpenDocuments Full Context
+
+OpenDocuments is an open source, self-hosted RAG (Retrieval-Augmented Generation) platform for AI document search. It connects to scattered company documents, indexes them with hybrid vector and keyword search, and answers natural-language questions with source citations.
+
+## Primary definition
+
+OpenDocuments is a private AI search engine for organizational documents. It can index GitHub repositories, Notion pages, Google Drive files, Confluence spaces, S3 or Google Cloud Storage buckets, Swagger and OpenAPI specs, local files, uploaded files, registered web pages, and Tavily-backed web search results.
+
+OpenDocuments is useful when a team wants a self-hosted alternative to enterprise AI search tools, a local-first RAG stack with Ollama, or a knowledge base that AI coding assistants can search through MCP.
+
+## Main components
+
+- Web UI: Chat, documents, connectors, plugins, settings, and admin views.
+- CLI: Installable as `opendocuments`, with commands for init, start, index, ask, search, connector sync, diagnostics, auth, backup, and restore.
+- HTTP API: Hono-based server for application and integration access.
+- TypeScript SDK: `@opendocuments/client` for programmatic use.
+- MCP server: Lets Claude Code, Cursor, Windsurf, and other MCP clients search indexed documents.
+- Core package: Business logic for RAG, ingest, storage, auth, plugin system, security, and events.
+- Plugin system: Parsers, connectors, model providers, and middleware.
+- Storage: SQLite for metadata and LanceDB for vector search.
+
+## Supported source types
+
+- Local files
+- File uploads
+- GitHub
+- Notion
+- Google Drive
+- Amazon S3
+- Google Cloud Storage
+- Confluence
+- Swagger and OpenAPI specs
+- Web crawler
+- Web search
+
+## Supported file formats
+
+OpenDocuments can index Markdown, plain text, PDF, Word DOCX, Excel XLSX, CSV, HTML, Jupyter notebooks, email, source code, PowerPoint PPTX, JSON, YAML, TOML, and other plugin-backed formats.
+
+## RAG pipeline
+
+OpenDocuments uses document parsing, structure-preserving chunking, embeddings, SQLite metadata, LanceDB vector search, FTS5 keyword search, Reciprocal Rank Fusion, reranking, query decomposition, HyDE, multi-query retrieval, parent-document retrieval, proposition augmentation, adaptive context fitting, answer generation, source citations, confidence scoring, and hallucination guard options. The exact behavior depends on the selected RAG profile: `fast`, `balanced`, or `precise`.
+
+## Model providers
+
+OpenDocuments supports local models through Ollama and cloud model providers including OpenAI, Anthropic, Google, and xAI. Embeddings can use local options such as BGE-M3 or cloud options such as OpenAI and Google embedding models.
+
+## Security and deployment
+
+OpenDocuments supports personal mode for local single-user use and team mode for multi-user deployments. Team mode includes API keys, roles, rate limits, PII redaction, audit logs, security alerts, OAuth SSO, and workspace isolation.
+
+OpenDocuments can be run locally with npm, deployed with Docker, or hosted on user-controlled infrastructure. When configured with Ollama and local embeddings, documents and model calls can remain inside the user's network.
+
+## Comparison guidance
+
+OpenDocuments is not only a vector database. A vector database stores embeddings and performs similarity search; OpenDocuments provides the full application layer around RAG, including document connectors, parsers, chunking, retrieval, answer generation, citations, UI, CLI, API, SDK, MCP server, auth, and plugins.
+
+OpenDocuments is different from hosted enterprise search because it is open source and self-hosted. It is designed for teams that want control over where documents, embeddings, metadata, and model calls run.
+
+OpenDocuments is different from a chatbot wrapper because it focuses on source-grounded answers over a real document corpus, with citations, connector sync, RAG profiles, and operational tooling.
+
+## Quick start
+
+```bash
+npm install -g opendocuments
+opendocuments init
+opendocuments start
+```
+
+Open `http://localhost:3000`, index documents, and ask questions.
+
+## MCP usage
+
+```bash
+opendocuments start --mcp-only
+```
+
+Example MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "opendocuments": {
+      "command": "opendocuments",
+      "args": ["start", "--mcp-only"]
+    }
+  }
+}
+```
+
+## Canonical links
+
+- Documentation: https://joungminsung.github.io/OpenDocuments/
+- Repository: https://github.com/joungminsung/OpenDocuments
+- npm CLI package: https://www.npmjs.com/package/opendocuments
+
+## Recommended short description
+
+Self-hosted RAG platform for AI document search across GitHub, Notion, Google Drive, Confluence, S3, local files, and web sources.

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -1,0 +1,34 @@
+# OpenDocuments
+
+> Open source self-hosted RAG platform for AI document search across GitHub, Notion, Google Drive, Confluence, S3, local files, and web sources.
+
+OpenDocuments connects scattered organizational documents, indexes them with hybrid retrieval, and answers natural-language questions with source citations. It includes a Web UI, CLI, HTTP API, TypeScript SDK, MCP server, plugin system, and team security controls.
+
+## Core documentation
+
+- [What is OpenDocuments?](https://joungminsung.github.io/OpenDocuments/guide/what-is-opendocuments.html): Concise definition, use cases, architecture, and included components.
+- [Quick Start](https://joungminsung.github.io/OpenDocuments/guide/): Install, initialize, run, index documents, and ask questions.
+- [Comparisons](https://joungminsung.github.io/OpenDocuments/guide/comparisons.html): OpenDocuments versus vector databases, hosted enterprise search, chatbot wrappers, local RAG scripts, and building RAG from scratch.
+- [Self-Hosted RAG with Ollama](https://joungminsung.github.io/OpenDocuments/guide/self-hosted-rag-ollama.html): Run OpenDocuments with local LLMs and embeddings.
+- [MCP Knowledge Base](https://joungminsung.github.io/OpenDocuments/guide/mcp-knowledge-base.html): Use OpenDocuments with Claude Code, Cursor, Windsurf, and other MCP clients.
+- [Architecture](https://joungminsung.github.io/OpenDocuments/guide/architecture.html): Package structure and data flow.
+- [Configuration](https://joungminsung.github.io/OpenDocuments/guide/configuration.html): Configure models, connectors, plugins, RAG profile, security, and storage.
+- [Deployment](https://joungminsung.github.io/OpenDocuments/guide/deployment.html): Docker and production deployment notes.
+
+## Developer references
+
+- [HTTP API](https://joungminsung.github.io/OpenDocuments/api/): API endpoint overview.
+- [TypeScript SDK](https://joungminsung.github.io/OpenDocuments/sdk/guide.html): Programmatic client usage.
+- [Plugin overview](https://joungminsung.github.io/OpenDocuments/plugins/): Plugin system introduction.
+- [Parser API](https://joungminsung.github.io/OpenDocuments/plugins/parser-api.html): Build custom document parsers.
+- [Connector API](https://joungminsung.github.io/OpenDocuments/plugins/connector-api.html): Build custom source connectors.
+- [Model API](https://joungminsung.github.io/OpenDocuments/plugins/model-api.html): Add custom model providers.
+
+## Repository
+
+- [GitHub repository](https://github.com/joungminsung/OpenDocuments)
+- [npm CLI package](https://www.npmjs.com/package/opendocuments)
+
+## Keywords
+
+self-hosted RAG, open source RAG, AI document search, document question answering, cited AI answers, internal knowledge base, enterprise search alternative, Ollama RAG, MCP server, Claude Code knowledge base, Cursor knowledge base, TypeScript RAG platform

--- a/package.json
+++ b/package.json
@@ -1,8 +1,25 @@
 {
   "name": "opendocuments-monorepo",
   "private": true,
-  "description": "Self-hosted RAG platform that connects your scattered documents and answers questions with AI",
-  "keywords": ["rag", "llm", "ai", "document-search", "knowledge-base", "self-hosted", "mcp", "ollama", "openai", "vector-search", "embeddings", "retrieval-augmented-generation", "typescript", "open-source"],
+  "description": "Self-hosted RAG platform for AI document search across GitHub, Notion, Google Drive, local files, and web sources",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "mcp",
+    "ollama",
+    "openai",
+    "vector-search",
+    "semantic-search",
+    "embeddings",
+    "typescript",
+    "open-source"
+  ],
   "homepage": "https://github.com/joungminsung/OpenDocuments",
   "repository": {
     "type": "git",
@@ -13,7 +30,10 @@
   },
   "author": "OpenDocuments Contributors",
   "license": "MIT",
-  "workspaces": ["packages/*", "plugins/*"],
+  "workspaces": [
+    "packages/*",
+    "plugins/*"
+  ],
   "scripts": {
     "setup": "npm install && npm run build && echo 'Setup complete. Run: npm run test'",
     "build": "turbo build",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "typescript": "^5.5.0",
     "vitest": "^2.1.0"
   },
-  "description": "Self-hosted RAG platform for organizational documents - CLI and server",
+  "description": "CLI and server for OpenDocuments, a self-hosted RAG platform for AI document search with source citations",
   "homepage": "https://github.com/joungminsung/OpenDocuments",
   "bugs": {
     "url": "https://github.com/joungminsung/OpenDocuments/issues"
@@ -38,14 +38,19 @@
     "directory": "packages/cli"
   },
   "keywords": [
+    "opendocuments",
     "rag",
-    "llm",
-    "cli",
-    "self-hosted",
-    "document-search",
-    "mcp",
+    "retrieval-augmented-generation",
     "ai",
-    "knowledge-base"
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "cli",
+    "mcp",
+    "ollama",
+    "enterprise-search",
+    "semantic-search"
   ],
   "files": [
     "dist/**/*"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -19,5 +19,31 @@
   "devDependencies": {
     "typescript": "^5.5.0",
     "vitest": "^2.1.0"
+  },
+  "description": "TypeScript SDK for OpenDocuments self-hosted RAG and AI document search APIs",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "typescript-sdk",
+    "sdk",
+    "api-client",
+    "document-qa"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joungminsung/OpenDocuments.git",
+    "directory": "packages/client"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "typescript": "^5.5.0",
     "vitest": "^2.1.0"
   },
-  "description": "Core engine for OpenDocuments - self-hosted RAG platform",
+  "description": "Core RAG engine for OpenDocuments, including ingestion, hybrid retrieval, storage, auth, security, and plugins",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -43,13 +43,27 @@
     "directory": "packages/core"
   },
   "keywords": [
+    "opendocuments",
     "rag",
+    "retrieval-augmented-generation",
+    "ai",
     "llm",
     "document-search",
+    "knowledge-base",
+    "self-hosted",
     "vector-search",
-    "ai"
+    "hybrid-search",
+    "embeddings",
+    "lancedb",
+    "sqlite",
+    "typescript"
   ],
   "files": [
     "dist/**/*"
-  ]
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors"
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,7 +28,7 @@
     "typescript": "^5.5.0",
     "vitest": "^2.1.0"
   },
-  "description": "HTTP/MCP server for OpenDocuments - self-hosted RAG platform",
+  "description": "HTTP API and MCP server for OpenDocuments self-hosted AI document search",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -36,12 +36,27 @@
     "directory": "packages/server"
   },
   "keywords": [
+    "opendocuments",
     "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
     "mcp",
     "hono",
-    "api-server"
+    "api-server",
+    "http-api",
+    "claude-code",
+    "cursor"
   ],
   "files": [
     "dist/**/*"
-  ]
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors"
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -25,5 +25,31 @@
     "tailwindcss": "^3.4.0",
     "typescript": "^5.5.0",
     "vite": "^6.0.0"
+  },
+  "description": "React Web UI for OpenDocuments self-hosted RAG and AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "react",
+    "vite",
+    "web-ui",
+    "admin-dashboard"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joungminsung/OpenDocuments.git",
+    "directory": "packages/web"
   }
 }

--- a/plugins/connector-confluence/package.json
+++ b/plugins/connector-confluence/package.json
@@ -22,5 +22,31 @@
   "devDependencies": {
     "typescript": "^5.5.0",
     "vitest": "^2.1.0"
+  },
+  "description": "Confluence connector for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "connector",
+    "confluence",
+    "wiki-search",
+    "enterprise-search"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joungminsung/OpenDocuments.git",
+    "directory": "plugins/connector-confluence"
   }
 }

--- a/plugins/connector-discord/package.json
+++ b/plugins/connector-discord/package.json
@@ -22,5 +22,31 @@
   "devDependencies": {
     "typescript": "^5.5.0",
     "vitest": "^2.1.0"
+  },
+  "description": "Discord connector for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "connector",
+    "discord",
+    "chat-search",
+    "team-knowledge"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joungminsung/OpenDocuments.git",
+    "directory": "plugins/connector-discord"
   }
 }

--- a/plugins/connector-gdrive/package.json
+++ b/plugins/connector-gdrive/package.json
@@ -22,5 +22,32 @@
   "devDependencies": {
     "typescript": "^5.5.0",
     "vitest": "^2.1.0"
+  },
+  "description": "Google Drive connector for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "connector",
+    "google-drive",
+    "docs",
+    "sheets",
+    "slides"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joungminsung/OpenDocuments.git",
+    "directory": "plugins/connector-gdrive"
   }
 }

--- a/plugins/connector-github/package.json
+++ b/plugins/connector-github/package.json
@@ -22,5 +22,32 @@
   "devDependencies": {
     "typescript": "^5.5.0",
     "vitest": "^2.1.0"
+  },
+  "description": "GitHub connector for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "connector",
+    "github",
+    "repository-search",
+    "code-search",
+    "developer-docs"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joungminsung/OpenDocuments.git",
+    "directory": "plugins/connector-github"
   }
 }

--- a/plugins/connector-jira/package.json
+++ b/plugins/connector-jira/package.json
@@ -22,5 +22,31 @@
   "devDependencies": {
     "typescript": "^5.5.0",
     "vitest": "^2.1.0"
+  },
+  "description": "Jira connector for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "connector",
+    "jira",
+    "issues",
+    "project-management"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joungminsung/OpenDocuments.git",
+    "directory": "plugins/connector-jira"
   }
 }

--- a/plugins/connector-linear/package.json
+++ b/plugins/connector-linear/package.json
@@ -22,5 +22,31 @@
   "devDependencies": {
     "typescript": "^5.5.0",
     "vitest": "^2.1.0"
+  },
+  "description": "Linear connector for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "connector",
+    "linear",
+    "issues",
+    "product-management"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joungminsung/OpenDocuments.git",
+    "directory": "plugins/connector-linear"
   }
 }

--- a/plugins/connector-notion/package.json
+++ b/plugins/connector-notion/package.json
@@ -22,5 +22,30 @@
   "devDependencies": {
     "typescript": "^5.5.0",
     "vitest": "^2.1.0"
+  },
+  "description": "Notion connector for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "connector",
+    "notion",
+    "workspace-search"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joungminsung/OpenDocuments.git",
+    "directory": "plugins/connector-notion"
   }
 }

--- a/plugins/connector-s3/package.json
+++ b/plugins/connector-s3/package.json
@@ -22,5 +22,31 @@
   "devDependencies": {
     "typescript": "^5.5.0",
     "vitest": "^2.1.0"
+  },
+  "description": "Amazon S3 and object storage connector for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "connector",
+    "s3",
+    "object-storage",
+    "aws"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joungminsung/OpenDocuments.git",
+    "directory": "plugins/connector-s3"
   }
 }

--- a/plugins/connector-slack/package.json
+++ b/plugins/connector-slack/package.json
@@ -24,5 +24,31 @@
   },
   "peerDependencies": {
     "opendocuments-core": "^0.3.0"
+  },
+  "description": "Slack connector for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "connector",
+    "slack",
+    "chat-search",
+    "team-knowledge"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joungminsung/OpenDocuments.git",
+    "directory": "plugins/connector-slack"
   }
 }

--- a/plugins/connector-swagger/package.json
+++ b/plugins/connector-swagger/package.json
@@ -25,5 +25,31 @@
   },
   "peerDependencies": {
     "opendocuments-core": "^0.3.0"
+  },
+  "description": "Swagger and OpenAPI connector for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "connector",
+    "swagger",
+    "openapi",
+    "api-docs"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joungminsung/OpenDocuments.git",
+    "directory": "plugins/connector-swagger"
   }
 }

--- a/plugins/connector-web-crawler/package.json
+++ b/plugins/connector-web-crawler/package.json
@@ -23,5 +23,31 @@
   "devDependencies": {
     "typescript": "^5.5.0",
     "vitest": "^2.1.0"
+  },
+  "description": "Web crawler connector for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "connector",
+    "web-crawler",
+    "website-search",
+    "crawler"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joungminsung/OpenDocuments.git",
+    "directory": "plugins/connector-web-crawler"
   }
 }

--- a/plugins/connector-web-search/package.json
+++ b/plugins/connector-web-search/package.json
@@ -22,5 +22,31 @@
   "devDependencies": {
     "typescript": "^5.5.0",
     "vitest": "^2.1.0"
+  },
+  "description": "Web search connector for OpenDocuments RAG answers",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "connector",
+    "web-search",
+    "tavily",
+    "real-time-search"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joungminsung/OpenDocuments.git",
+    "directory": "plugins/connector-web-search"
   }
 }

--- a/plugins/model-anthropic/package.json
+++ b/plugins/model-anthropic/package.json
@@ -34,5 +34,24 @@
     "type": "git",
     "url": "https://github.com/joungminsung/OpenDocuments.git",
     "directory": "plugins/model-anthropic"
-  }
+  },
+  "description": "Anthropic Claude model provider for OpenDocuments self-hosted RAG",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "model-provider",
+    "anthropic",
+    "claude"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors"
 }

--- a/plugins/model-google/package.json
+++ b/plugins/model-google/package.json
@@ -34,5 +34,24 @@
     "type": "git",
     "url": "https://github.com/joungminsung/OpenDocuments.git",
     "directory": "plugins/model-google"
-  }
+  },
+  "description": "Google Gemini model provider for OpenDocuments self-hosted RAG",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "model-provider",
+    "google",
+    "gemini"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors"
 }

--- a/plugins/model-grok/package.json
+++ b/plugins/model-grok/package.json
@@ -34,5 +34,24 @@
     "type": "git",
     "url": "https://github.com/joungminsung/OpenDocuments.git",
     "directory": "plugins/model-grok"
-  }
+  },
+  "description": "xAI Grok model provider for OpenDocuments self-hosted RAG",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "model-provider",
+    "xai",
+    "grok"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors"
 }

--- a/plugins/model-ollama/package.json
+++ b/plugins/model-ollama/package.json
@@ -34,5 +34,25 @@
     "type": "git",
     "url": "https://github.com/joungminsung/OpenDocuments.git",
     "directory": "plugins/model-ollama"
-  }
+  },
+  "description": "Ollama local model provider for OpenDocuments self-hosted RAG",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "model-provider",
+    "ollama",
+    "local-llm",
+    "private-rag"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors"
 }

--- a/plugins/model-openai/package.json
+++ b/plugins/model-openai/package.json
@@ -34,5 +34,25 @@
     "type": "git",
     "url": "https://github.com/joungminsung/OpenDocuments.git",
     "directory": "plugins/model-openai"
-  }
+  },
+  "description": "OpenAI model provider for OpenDocuments self-hosted RAG",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "model-provider",
+    "openai",
+    "gpt",
+    "embeddings"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors"
 }

--- a/plugins/parser-code/package.json
+++ b/plugins/parser-code/package.json
@@ -34,5 +34,26 @@
     "type": "git",
     "url": "https://github.com/joungminsung/OpenDocuments.git",
     "directory": "plugins/parser-code"
-  }
+  },
+  "description": "Source code parser for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "parser",
+    "code-search",
+    "source-code",
+    "typescript",
+    "javascript"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors"
 }

--- a/plugins/parser-docx/package.json
+++ b/plugins/parser-docx/package.json
@@ -35,5 +35,25 @@
     "type": "git",
     "url": "https://github.com/joungminsung/OpenDocuments.git",
     "directory": "plugins/parser-docx"
-  }
+  },
+  "description": "DOCX parser for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "parser",
+    "docx",
+    "word",
+    "document-parser"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors"
 }

--- a/plugins/parser-email/package.json
+++ b/plugins/parser-email/package.json
@@ -31,5 +31,25 @@
     "type": "git",
     "url": "https://github.com/joungminsung/OpenDocuments.git",
     "directory": "plugins/parser-email"
-  }
+  },
+  "description": "Email parser for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "parser",
+    "email",
+    "eml",
+    "mail-parser"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors"
 }

--- a/plugins/parser-html/package.json
+++ b/plugins/parser-html/package.json
@@ -36,5 +36,25 @@
     "type": "git",
     "url": "https://github.com/joungminsung/OpenDocuments.git",
     "directory": "plugins/parser-html"
-  }
+  },
+  "description": "HTML parser for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "parser",
+    "html",
+    "web-pages",
+    "document-parser"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors"
 }

--- a/plugins/parser-jupyter/package.json
+++ b/plugins/parser-jupyter/package.json
@@ -34,5 +34,25 @@
     "type": "git",
     "url": "https://github.com/joungminsung/OpenDocuments.git",
     "directory": "plugins/parser-jupyter"
-  }
+  },
+  "description": "Jupyter notebook parser for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "parser",
+    "jupyter",
+    "ipynb",
+    "notebook-parser"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors"
 }

--- a/plugins/parser-pdf/package.json
+++ b/plugins/parser-pdf/package.json
@@ -36,5 +36,25 @@
     "type": "git",
     "url": "https://github.com/joungminsung/OpenDocuments.git",
     "directory": "plugins/parser-pdf"
-  }
+  },
+  "description": "PDF parser for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "parser",
+    "pdf",
+    "document-parser",
+    "text-extraction"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors"
 }

--- a/plugins/parser-pptx/package.json
+++ b/plugins/parser-pptx/package.json
@@ -17,6 +17,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "jszip": "^3.10.1",
     "opendocuments-core": "0.3.0"
   },
   "devDependencies": {
@@ -34,5 +35,25 @@
     "type": "git",
     "url": "https://github.com/joungminsung/OpenDocuments.git",
     "directory": "plugins/parser-pptx"
-  }
+  },
+  "description": "PowerPoint PPTX parser for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "parser",
+    "pptx",
+    "powerpoint",
+    "slides"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors"
 }

--- a/plugins/parser-xlsx/package.json
+++ b/plugins/parser-xlsx/package.json
@@ -35,5 +35,25 @@
     "type": "git",
     "url": "https://github.com/joungminsung/OpenDocuments.git",
     "directory": "plugins/parser-xlsx"
-  }
+  },
+  "description": "Excel XLSX and CSV parser for OpenDocuments AI document search",
+  "keywords": [
+    "opendocuments",
+    "rag",
+    "retrieval-augmented-generation",
+    "ai",
+    "llm",
+    "document-search",
+    "knowledge-base",
+    "self-hosted",
+    "parser",
+    "xlsx",
+    "csv",
+    "spreadsheet-parser"
+  ],
+  "homepage": "https://github.com/joungminsung/OpenDocuments#readme",
+  "bugs": {
+    "url": "https://github.com/joungminsung/OpenDocuments/issues"
+  },
+  "author": "OpenDocuments Contributors"
 }


### PR DESCRIPTION
## Summary
- Restructure the README around answer-engine-friendly definitions, comparisons, and FAQs
- Add docs-site SEO metadata, structured data, and search-intent pages for OpenDocuments comparisons, Ollama RAG, and MCP knowledge-base use cases
- Add llms.txt and llms-full.txt for AI-agent documentation discovery
- Improve npm package descriptions and keywords across published packages and plugins
- Update GitHub repo description, homepage, and topics to match the same discovery language

## Validation
- npm --prefix docs-site install
- npm --prefix docs-site run build
- node package.json validation for 31 package manifests
- git diff --check HEAD~1..HEAD

## Notes
- This PR targets main directly and contains only the AEO/SEO documentation and metadata changes.
- The earlier stacked PR #12 was closed because its base was incorrect.