### PR TITLE
ci: update GitHub Pages actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: 20
       - run: cd docs-site && npm install && npm run build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs-site/.vitepress/dist
 
@@ -35,4 +35,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

- update `actions/upload-pages-artifact` from v3 to v5
- update `actions/deploy-pages` from v4 to v5
- remove the Node.js 20 action-runtime deprecation warning observed after merging PR #18

## Validation

- versions verified against the official latest GitHub Action releases
- `git diff --check` passed