### PR TITLE
ci: build and verify the Docker image on amd64 and arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,102 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'package*.json'
+      - 'turbo.json'
+      - 'tsconfig.base.json'
+      - 'packages/**'
+      - 'plugins/**'
+      - '.github/workflows/docker.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'package*.json'
+      - 'turbo.json'
+      - 'tsconfig.base.json'
+      - 'packages/**'
+      - 'plugins/**'
+      - '.github/workflows/docker.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Each platform builds on a native runner rather than under QEMU.
+          # Emulation is not just slower here: esbuild is a Go binary, and Go
+          # binaries reliably abort under qemu-user with "fatal error:
+          # lfstack.push" during the Vite build.
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          tags: opendocuments:${{ matrix.arch }}
+          load: true
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      - name: Verify image architecture
+        run: |
+          actual="$(docker image inspect --format '{{.Architecture}}' opendocuments:${{ matrix.arch }})"
+          if [ "$actual" != "${{ matrix.arch }}" ]; then
+            echo "Expected ${{ matrix.arch }} image, got $actual"
+            exit 1
+          fi
+
+      # The arch-specific risk is the native modules: LanceDB ships a prebuilt
+      # binary per platform, and better-sqlite3 resolves one at install time.
+      - name: Verify native modules load
+        run: |
+          docker run --rm --entrypoint node opendocuments:${{ matrix.arch }} -e "
+            require('@lancedb/lancedb');
+            const db = new (require('better-sqlite3'))(':memory:');
+            db.exec('CREATE TABLE t (x)');
+            console.log('native modules loaded on ' + process.arch);
+          "
+
+      - name: Verify the server starts
+        run: |
+          cid="$(docker run -d -p 3000:3000 opendocuments:${{ matrix.arch }})"
+          for _ in $(seq 1 30); do
+            if curl -fsS http://localhost:3000/healthz; then
+              started=1
+              break
+            fi
+            sleep 2
+          done
+          if [ -z "${started:-}" ]; then
+            docker logs "$cid"
+            docker rm -f "$cid"
+            exit 1
+          fi
+          docker rm -f "$cid"

--- a/README.ko.md
+++ b/README.ko.md
@@ -556,6 +556,18 @@ docker run -v ./opendocuments.config.ts:/app/opendocuments.config.ts \
   -v opendocuments-data:/data -p 3000:3000 opendocuments
 ```
 
+### 아키텍처 지원
+
+이미지는 `linux/amd64`와 `linux/arm64` 모두에서 빌드되고 실행됩니다. Apple Silicon Mac에서는 추가 flag가 필요 없습니다. `docker compose up -d`는 host 아키텍처에 맞춰 native로 빌드하며, LanceDB와 better-sqlite3 native module도 ARM64 빌드로 설치됩니다.
+
+두 아키텍처를 모두 지원하는 단일 이미지를 만들려면:
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t opendocuments:latest .
+```
+
+multi-platform 빌드는 단일 이미지가 아니라 manifest list를 생성합니다. registry에 게시하려면 `--push`를 추가하세요. 로컬에서 사용하려면 `--load`와 함께 한 번에 하나의 platform만 빌드하세요.
+
 ---
 
 ## 플러그인 개발

--- a/README.md
+++ b/README.md
@@ -550,6 +550,22 @@ docker run -v ./opendocuments.config.ts:/app/opendocuments.config.ts \
   -v opendocuments-data:/data -p 3000:3000 opendocuments
 ```
 
+### Architecture support
+
+The image builds and runs on both `linux/amd64` and `linux/arm64`. Apple Silicon
+Macs need no extra flags — `docker compose up -d` builds natively for your host,
+and the LanceDB and better-sqlite3 native modules resolve to their ARM64 builds.
+
+To produce a single image that serves both architectures:
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t opendocuments:latest .
+```
+
+A multi-platform build produces a manifest list rather than a single image, so
+add `--push` to publish it to a registry. For local use, build one platform at a
+time with `--load`.
+
 ---
 
 ## Plugin Development


### PR DESCRIPTION
## Summary

Adds a `Docker` workflow that builds the image for **`linux/amd64` and `linux/arm64`** and verifies each one actually works, plus docs for building a multi-platform image.

One note on the issue's premise: the Dockerfile is **not** x86-only today. The `case "$node_arch"` block added in 6358786 already installs the `arm64` Rollup/LanceDB packages, and `optionalDependencies` already lists `@lancedb/lancedb-linux-arm64-gnu`. I built and ran the image on an M-series Mac with no changes and it works. So the real gap was that nothing *exercised* the ARM64 path — it could regress silently — and nothing documented it. This PR closes that gap rather than changing the Dockerfile.

## Type of Change
- [x] New feature (CI coverage)
- [x] Documentation update

## Related Issue

Closes #4

## Why native runners instead of `--platform linux/amd64,linux/arm64`

The issue suggests a single QEMU build with both platforms. I tried that first and it does not work reliably: esbuild is a Go binary, and Go binaries abort under `qemu-user` partway through the Vite build.

```
@opendocuments/web:build: fatal error: lfstack.push
@opendocuments/web:build: [vite:esbuild] The service was stopped
```

So the workflow builds each platform on a native runner instead — `ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64 (free for public repos). This is also much faster than emulating the monorepo build. `docker buildx build --platform linux/amd64,linux/arm64` is still the right command for a *user* on their own machine, and it is what the README now documents.

## Test Plan

Verified locally on an Apple Silicon Mac (`linux/arm64`, built natively):

- `docker buildx build --platform linux/arm64` — succeeds
- `docker image inspect --format '{{.Architecture}}'` → `arm64`
- `require('@lancedb/lancedb')` and `better-sqlite3` load and run a real query inside the container → `arch: arm64`, `sqlite rows: 1`
- Container boots and `GET /healthz` returns `{"status":"ok"}` with `HEALTHCHECK` reporting `healthy`, using no model config (it degrades to stub models and still serves)

These are exactly the three checks the workflow runs, so amd64 gets the same treatment on a native x86 runner. I could not verify the amd64 leg locally for the QEMU reason above — that one runs for the first time on this PR.

`.github/workflows/docker.yml` passes `actionlint`.

## Notes

- The workflow is build-and-verify only — it does not push anywhere. If you'd like it to publish a multi-arch manifest to GHCR on `main`/tags, I'm happy to add that; I left it out since it's a packaging decision that's yours to make.
- `paths:` filters keep it off doc-only PRs.
- No changeset: nothing here affects a published package.
