### PR TITLE
fix(core): stem FTS5 tokens and honor the embeddingProvider override

### DIFF
--- a/.changeset/fts-stemming-and-embedding-provider.md
+++ b/.changeset/fts-stemming-and-embedding-provider.md
@@ -1,0 +1,10 @@
+---
+"opendocuments-core": patch
+"opendocuments-server": patch
+---
+
+Fix two retrieval defects.
+
+- FTS5 now uses Porter stemming. Under the previous `unicode61` tokenizer a query for `authenticate` scored zero hits against a chunk containing "authentication", as did `rotate`/`rotates`, `debug`/`debugging` and `fail`/`failed`. Because the lexical leg feeds one half of the hybrid RRF merge, those misses dropped candidates out of retrieval rather than merely reordering them. The migration rebuilds the index in place from the existing rows, so no re-embedding or reindex is required.
+
+- `model.embeddingProvider` was consulted only when the main provider could not embed at all, so it was silently ignored for providers like Ollama and OpenAI that can. Embedding dimensions are resolved from that same setting, so a config pairing an Ollama LLM with a different embedder created the vector collection at the override's width and then filled it with the main provider's vectors. The ingest pipeline now also takes the embedder explicitly rather than scanning the plugin registry, which would otherwise pick whichever provider registered first and index through a different model than retrieval queries with.

--- a/packages/core/src/ingest/pipeline.ts
+++ b/packages/core/src/ingest/pipeline.ts
@@ -8,7 +8,7 @@ import { generateChunkContexts } from '../rag/contextual.js'
 import { getProfileConfig } from '../rag/profiles.js'
 import { sha256 } from '../utils/hash.js'
 import type { StoredChunk } from './document-store.js'
-import type { ParsedChunk, RawDocument, ParserPlugin } from '../plugin/interfaces.js'
+import type { ParsedChunk, RawDocument, ParserPlugin, ModelPlugin } from '../plugin/interfaces.js'
 import type { OpenDocumentsConfig } from '../config/schema.js'
 import type { PIIRedactor } from '../security/redactor.js'
 import type { DocumentVersionManager } from '../document/version-manager.js'
@@ -39,6 +39,16 @@ export interface IngestPipelineOptions {
   config?: OpenDocumentsConfig
   redactor?: PIIRedactor
   versionManager?: DocumentVersionManager
+  /**
+   * Embedding provider to index with. Must be the same instance retrieval uses,
+   * or documents get embedded by one provider and queried through another.
+   *
+   * Falling back to "first embedding-capable plugin in the registry" is not safe
+   * once `model.embeddingProvider` can name a provider other than the main one:
+   * the main plugin registers first, so the registry scan picks it over the
+   * configured embedder and writes vectors of the wrong width.
+   */
+  embedder?: ModelPlugin
 }
 
 const BATCH_SIZE = 32
@@ -159,9 +169,11 @@ export class IngestPipeline {
       // Apply before:chunk middleware
       await middleware.run('before:chunk', parsedChunks)
 
-      // Resolve embedder early -- semantic chunking needs it
-      const models = registry.getModels()
-      const embeddingModel = models.find(m => m.capabilities.embedding && m.embed)
+      // Resolve embedder early -- semantic chunking needs it.
+      // Prefer the explicitly configured embedder; the registry scan is a fallback
+      // for callers that do not supply one and picks whichever model registered first.
+      const embeddingModel = this.opts.embedder
+        ?? registry.getModels().find(m => m.capabilities.embedding && m.embed)
       const embedFn = embeddingModel?.embed?.bind(embeddingModel) ?? null
 
       // Embedder is required to index; bail early if missing

--- a/packages/core/src/storage/migrations/009_fts5_porter_stemming.sql
+++ b/packages/core/src/storage/migrations/009_fts5_porter_stemming.sql
@@ -1,0 +1,27 @@
+-- Switch the FTS5 index to Porter stemming.
+--
+-- The original `unicode61` tokenizer matches surface forms only, so a query for
+-- "authenticate" scored zero hits against a chunk containing "authentication",
+-- as did "rotate"/"rotates", "debug"/"debugging" and "fail"/"failed". Since the
+-- lexical leg feeds one half of the hybrid RRF merge, those misses removed
+-- candidates from retrieval entirely rather than merely reordering them.
+--
+-- `porter unicode61` layers the Porter stemmer over the same character-class
+-- tokenizer, so tokenization is unchanged and only the stem folding is added.
+--
+-- An FTS5 table's tokenizer is fixed at creation, so the index is rebuilt.
+-- chunks_fts is a standalone (non-external-content) table holding both chunk_id
+-- and content, so the existing rows are copied across without touching LanceDB
+-- or re-embedding anything.
+CREATE VIRTUAL TABLE chunks_fts_porter USING fts5(
+  chunk_id,
+  content,
+  tokenize='porter unicode61'
+);
+
+INSERT INTO chunks_fts_porter (chunk_id, content)
+  SELECT chunk_id, content FROM chunks_fts;
+
+DROP TABLE chunks_fts;
+
+ALTER TABLE chunks_fts_porter RENAME TO chunks_fts;

--- a/packages/core/tests/ingest/embedder-routing.test.ts
+++ b/packages/core/tests/ingest/embedder-routing.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { IngestPipeline } from '../../src/ingest/pipeline.js'
+import { DocumentStore } from '../../src/ingest/document-store.js'
+import { MarkdownParser } from '../../src/parsers/markdown.js'
+import { PluginRegistry } from '../../src/plugin/registry.js'
+import { EventBus } from '../../src/events/bus.js'
+import { MiddlewareRunner } from '../../src/ingest/middleware.js'
+import { createSQLiteDB } from '../../src/storage/sqlite.js'
+import { createLanceDB } from '../../src/storage/lancedb.js'
+import { runMigrations } from '../../src/storage/migrations/runner.js'
+import type { DB } from '../../src/storage/db.js'
+import type { VectorDB } from '../../src/storage/vector-db.js'
+import type { PluginContext, ModelPlugin } from '../../src/plugin/interfaces.js'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+/** Records which embedder was asked to embed, so routing is directly observable. */
+function trackingEmbedder(name: string, log: string[]): ModelPlugin {
+  return {
+    name,
+    type: 'model',
+    version: '0.3.0',
+    coreVersion: '^0.3.0',
+    capabilities: { embedding: true },
+    setup: vi.fn().mockResolvedValue(undefined),
+    async embed(texts: string[]) {
+      log.push(name)
+      return { dense: texts.map(() => [0.1, 0.2, 0.3]) }
+    },
+  }
+}
+
+/**
+ * `model.embeddingProvider` selects the embedder, and embedding dimensions are
+ * resolved from that same setting. If ingest picks a different provider than
+ * retrieval, documents are embedded at one width and queried at another. The
+ * pipeline must therefore use the embedder it is handed, not whichever
+ * embedding-capable plugin happens to have registered first.
+ */
+describe('IngestPipeline embedder routing', () => {
+  let db: DB
+  let vectorDb: VectorDB
+  let tempDir: string
+  let store: DocumentStore
+  let registry: PluginRegistry
+  let eventBus: EventBus
+  let middleware: MiddlewareRunner
+  let ctx: PluginContext
+
+  beforeEach(async () => {
+    db = createSQLiteDB(':memory:')
+    runMigrations(db)
+    tempDir = mkdtempSync(join(tmpdir(), 'opendocuments-test-'))
+    vectorDb = await createLanceDB(tempDir)
+
+    registry = new PluginRegistry()
+    eventBus = new EventBus()
+    middleware = new MiddlewareRunner()
+    ctx = { config: {}, dataDir: tempDir, log: console as any }
+    await registry.register(new MarkdownParser(), ctx)
+
+    store = new DocumentStore(db, vectorDb, 'ws-1')
+    await store.initialize(3)
+  })
+
+  afterEach(async () => {
+    db.close()
+    await vectorDb.close()
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  async function ingest(embedder?: ModelPlugin) {
+    const pipeline = new IngestPipeline({
+      store, registry, eventBus, middleware, embeddingDimensions: 3, embedder,
+    })
+    return pipeline.ingest({
+      title: 'doc.md',
+      content: '# Title\n\nSome indexed prose.',
+      sourceType: 'local',
+      sourcePath: '/doc.md',
+      fileType: '.md',
+    })
+  }
+
+  it('uses the supplied embedder over one already in the registry', async () => {
+    // Mirrors bootstrap's registration order: the main provider registers first,
+    // so a registry scan would pick it and ignore the configured override.
+    const used: string[] = []
+    await registry.register(trackingEmbedder('main-provider', used), ctx)
+
+    const result = await ingest(trackingEmbedder('configured-embedder', used))
+
+    expect(result.status).toBe('indexed')
+    expect(used).toContain('configured-embedder')
+    expect(used).not.toContain('main-provider')
+  })
+
+  it('falls back to the registry when no embedder is supplied', async () => {
+    const used: string[] = []
+    await registry.register(trackingEmbedder('main-provider', used), ctx)
+
+    const result = await ingest()
+
+    expect(result.status).toBe('indexed')
+    expect(used).toContain('main-provider')
+  })
+
+  it('errors cleanly when neither a supplied nor a registered embedder exists', async () => {
+    const result = await ingest()
+    expect(result.status).toBe('error')
+    expect(store.getDocument(result.documentId)?.error_message).toMatch(/No embedding model/)
+  })
+})

--- a/packages/core/tests/ingest/embedder-routing.test.ts
+++ b/packages/core/tests/ingest/embedder-routing.test.ts
@@ -15,6 +15,14 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
+/** Typed no-op logger, so the test context satisfies PluginContext without a cast. */
+const silentLog: PluginContext['log'] = {
+  ok: () => {},
+  fail: () => {},
+  info: () => {},
+  wait: () => {},
+}
+
 /** Records which embedder was asked to embed, so routing is directly observable. */
 function trackingEmbedder(name: string, log: string[]): ModelPlugin {
   return {
@@ -57,7 +65,7 @@ describe('IngestPipeline embedder routing', () => {
     registry = new PluginRegistry()
     eventBus = new EventBus()
     middleware = new MiddlewareRunner()
-    ctx = { config: {}, dataDir: tempDir, log: console as any }
+    ctx = { config: {}, dataDir: tempDir, log: silentLog }
     await registry.register(new MarkdownParser(), ctx)
 
     store = new DocumentStore(db, vectorDb, 'ws-1')

--- a/packages/core/tests/storage/fts-stemming.test.ts
+++ b/packages/core/tests/storage/fts-stemming.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createSQLiteDB } from '../../src/storage/sqlite.js'
+import { runMigrations } from '../../src/storage/migrations/runner.js'
+import type { DB } from '../../src/storage/db.js'
+
+describe('FTS5 Porter stemming', () => {
+  let db: DB
+
+  beforeEach(() => {
+    db = createSQLiteDB(':memory:')
+    runMigrations(db)
+    db.run('INSERT INTO chunks_fts (chunk_id, content) VALUES (?, ?)', [
+      'd1_chunk_0', 'the authentication service rotates keys automatically',
+    ])
+    db.run('INSERT INTO chunks_fts (chunk_id, content) VALUES (?, ?)', [
+      'd1_chunk_1', 'debugging the retry logic for failed uploads',
+    ])
+  })
+
+  afterEach(() => db.close())
+
+  const hits = (term: string) =>
+    db.all<{ chunk_id: string }>(
+      'SELECT chunk_id FROM chunks_fts WHERE chunks_fts MATCH ?', [`"${term}"`],
+    )
+
+  // Each of these scored zero under the original `unicode61` tokenizer, which
+  // matched surface forms only. Because the lexical leg feeds retrieval rather
+  // than just ordering, those misses dropped candidates entirely.
+  it.each([
+    ['authenticate', 'd1_chunk_0'],
+    ['rotate', 'd1_chunk_0'],
+    ['debug', 'd1_chunk_1'],
+    ['fail', 'd1_chunk_1'],
+    ['upload', 'd1_chunk_1'],
+  ])('matches %s against its inflected form', (term, expected) => {
+    expect(hits(term).map(r => r.chunk_id)).toContain(expected)
+  })
+
+  it('still matches exact surface forms', () => {
+    expect(hits('authentication').map(r => r.chunk_id)).toContain('d1_chunk_0')
+  })
+
+  it('does not match unrelated terms', () => {
+    expect(hits('quantum')).toHaveLength(0)
+  })
+
+  it('preserves rows written before the migration ran', () => {
+    // Simulate a pre-migration index, then re-run migrations over it.
+    const legacy = createSQLiteDB(':memory:')
+    legacy.exec(`
+      CREATE TABLE IF NOT EXISTS schema_migrations (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL UNIQUE,
+        applied_at TEXT DEFAULT (datetime('now'))
+      )
+    `)
+    legacy.exec(`CREATE VIRTUAL TABLE chunks_fts USING fts5(chunk_id, content, tokenize='unicode61')`)
+    legacy.run('INSERT INTO chunks_fts (chunk_id, content) VALUES (?, ?)', [
+      'legacy_chunk_0', 'the authentication service rotates keys',
+    ])
+    for (const name of [
+      '001_initial.sql', '002_add_versioning_collections.sql', '003_add_source_path_index.sql',
+      '004_add_api_keys.sql', '005_add_api_keys_revoked_at.sql', '006_add_fts5.sql',
+      '007_add_api_key_allowed_ips.sql', '008_add_source_version.sql',
+    ]) {
+      legacy.run('INSERT INTO schema_migrations (name) VALUES (?)', [name])
+    }
+
+    runMigrations(legacy)
+
+    const rows = legacy.all<{ chunk_id: string }>(
+      'SELECT chunk_id FROM chunks_fts WHERE chunks_fts MATCH ?', ['"authenticate"'],
+    )
+    expect(rows.map(r => r.chunk_id)).toContain('legacy_chunk_0')
+    legacy.close()
+  })
+})

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -218,6 +218,26 @@ async function loadSinglePlugin(
   }
 }
 
+/**
+ * Decide whether embeddings should be routed to a provider other than the main one.
+ *
+ * `model.embeddingProvider` used to be consulted only when the main provider could
+ * not embed at all, so a config pairing e.g. an Ollama LLM with a different embedder
+ * was silently ignored. That was more than an ignored preference: embedding
+ * dimensions are resolved from `embeddingProvider`, so the vector collection was
+ * created at the override's width and then filled with the main provider's vectors.
+ *
+ * Returns undefined when the main provider should embed (no override, or the
+ * override names that same provider).
+ */
+export function resolveEmbeddingProviderOverride(
+  provider: string,
+  embeddingProvider: string | undefined,
+): string | undefined {
+  if (!embeddingProvider) return undefined
+  return embeddingProvider === provider ? undefined : embeddingProvider
+}
+
 async function loadModelPlugin(
   provider: string,
   modelConfig: OpenDocumentsConfig['model'],
@@ -253,11 +273,14 @@ async function loadModelPlugin(
     const maxRetries = parseInt(process.env.OPENDOCUMENTS_PROBE_RETRIES || '3', 10)
     const retryDelay = parseInt(process.env.OPENDOCUMENTS_PROBE_DELAY_MS || '3000', 10)
 
+    const embeddingOverride = resolveEmbeddingProviderOverride(provider, modelConfig.embeddingProvider)
+
     // Probe the embedding capability with a test call to verify the plugin is
     // actually functional (e.g. the remote model server is running with the
     // required model installed). Fall back to stubs on any failure so that the
     // server can still start and serve requests in degraded mode.
-    if (mainPlugin.capabilities.embedding && mainPlugin.embed) {
+    // Only probe the main plugin's embedder when it will actually be used as one.
+    if (!embeddingOverride && mainPlugin.capabilities.embedding && mainPlugin.embed) {
       let probeSuccess = false
       for (let attempt = 1; attempt <= maxRetries; attempt++) {
         try {
@@ -280,10 +303,15 @@ async function loadModelPlugin(
       }
     }
 
-    // If the main plugin doesn't support embedding, load a secondary embedding provider
-    if (!mainPlugin.capabilities.embedding) {
-      const embeddingProvider = modelConfig.embeddingProvider || 'ollama'
-      log.info(`Main provider '${provider}' does not support embedding. Loading secondary embedding provider: ${embeddingProvider}`)
+    // Load a secondary embedding provider when the main plugin cannot embed, or when
+    // the config explicitly points embeddings at a different provider.
+    if (embeddingOverride || !mainPlugin.capabilities.embedding) {
+      const embeddingProvider = embeddingOverride ?? (modelConfig.embeddingProvider || 'ollama')
+      log.info(
+        embeddingOverride
+          ? `Embeddings routed to configured provider '${embeddingProvider}' (LLM stays on '${provider}').`
+          : `Main provider '${provider}' does not support embedding. Loading secondary embedding provider: ${embeddingProvider}`
+      )
 
       const embeddingPlugin = await loadSinglePlugin(
         embeddingProvider,
@@ -632,6 +660,9 @@ export async function bootstrap(opts: BootstrapOptions = {}): Promise<AppContext
           config,
           redactor,
           versionManager,
+          // Must match the embedder the RAG engine queries with, otherwise an
+          // `embeddingProvider` override indexes and retrieves through different models.
+          embedder,
         })
         pipelines.set(workspaceId, scopedPipeline)
       }

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -228,14 +228,17 @@ async function loadSinglePlugin(
  * created at the override's width and then filled with the main provider's vectors.
  *
  * Returns undefined when the main provider should embed (no override, or the
- * override names that same provider).
+ * override names that same provider). The value is trimmed first: it reaches us
+ * straight from config or the environment, and a blank-but-not-empty string would
+ * otherwise be treated as a provider name and fail plugin lookup.
  */
 export function resolveEmbeddingProviderOverride(
   provider: string,
   embeddingProvider: string | undefined,
 ): string | undefined {
-  if (!embeddingProvider) return undefined
-  return embeddingProvider === provider ? undefined : embeddingProvider
+  const override = embeddingProvider?.trim()
+  if (!override) return undefined
+  return override === provider.trim() ? undefined : override
 }
 
 async function loadModelPlugin(

--- a/packages/server/tests/embedding-provider-override.test.ts
+++ b/packages/server/tests/embedding-provider-override.test.ts
@@ -21,6 +21,18 @@ describe('resolveEmbeddingProviderOverride', () => {
     expect(resolveEmbeddingProviderOverride('ollama', '')).toBeUndefined()
   })
 
+  it('treats a whitespace-only override as unset', () => {
+    // Reaches us untrimmed from config or the environment; left as-is it would be
+    // taken for a provider name and fail plugin lookup.
+    expect(resolveEmbeddingProviderOverride('ollama', '   ')).toBeUndefined()
+    expect(resolveEmbeddingProviderOverride('ollama', '\t\n')).toBeUndefined()
+  })
+
+  it('trims a padded override rather than passing it through', () => {
+    expect(resolveEmbeddingProviderOverride('ollama', '  openai  ')).toBe('openai')
+    expect(resolveEmbeddingProviderOverride('ollama', '  ollama  ')).toBeUndefined()
+  })
+
   it('still routes when the main provider cannot embed at all', () => {
     expect(resolveEmbeddingProviderOverride('anthropic', 'ollama')).toBe('ollama')
   })

--- a/packages/server/tests/embedding-provider-override.test.ts
+++ b/packages/server/tests/embedding-provider-override.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { resolveEmbeddingProviderOverride } from '../src/bootstrap.js'
+
+describe('resolveEmbeddingProviderOverride', () => {
+  it('routes embeddings elsewhere when a different provider is configured', () => {
+    // The regression: `ollama` can embed, so the override used to be dropped and
+    // embeddings silently came from Ollama at a width the collection did not expect.
+    expect(resolveEmbeddingProviderOverride('ollama', 'bge-m3')).toBe('bge-m3')
+    expect(resolveEmbeddingProviderOverride('ollama', 'openai')).toBe('openai')
+  })
+
+  it('keeps embeddings on the main provider when none is configured', () => {
+    expect(resolveEmbeddingProviderOverride('ollama', undefined)).toBeUndefined()
+  })
+
+  it('treats an override naming the main provider as no override', () => {
+    expect(resolveEmbeddingProviderOverride('openai', 'openai')).toBeUndefined()
+  })
+
+  it('treats an empty override as unset', () => {
+    expect(resolveEmbeddingProviderOverride('ollama', '')).toBeUndefined()
+  })
+
+  it('still routes when the main provider cannot embed at all', () => {
+    expect(resolveEmbeddingProviderOverride('anthropic', 'ollama')).toBe('ollama')
+  })
+})


### PR DESCRIPTION
## Summary

Two independent retrieval defects, both provider-agnostic and both affecting the default setup.

**1. FTS5 matched surface forms only.** The index was created with `tokenize='unicode61'`, which does no stem folding. Every one of these scores zero hits today:

| query | chunk contains | `unicode61` | `porter unicode61` |
|---|---|:---:|:---:|
| `authenticate` | "authentication" | **0** | 1 |
| `rotate` | "rotates" | **0** | 1 |
| `debug` | "debugging" | **0** | 1 |
| `fail` | "failed" | **0** | 1 |

Because the lexical leg feeds one half of the hybrid RRF merge in `Retriever.retrieve`, these are not ranking misses — the candidate never enters the funnel, and no downstream reranking can recover it.

`porter unicode61` layers the Porter stemmer over the same character-class tokenizer, so tokenization is unchanged and only stem folding is added. An FTS5 table's tokenizer is fixed at creation, so the migration rebuilds the index from the existing rows. `chunks_fts` is a standalone table holding its own content, so **nothing is re-embedded and no reindex is required**.

**2. `model.embeddingProvider` was silently ignored.** It was consulted only when the main provider could not embed at all (`if (!mainPlugin.capabilities.embedding)`), so it was dropped for Ollama and OpenAI, which can. Embedding dimensions are resolved from that same field, so:

```typescript
model: { provider: 'ollama', embeddingProvider: 'openai' }
```

created a 1536-D LanceDB collection and then filled it with 1024-D Ollama vectors.

`IngestPipeline` had a matching problem: it resolved its embedder by scanning the registry for the first embedding-capable plugin. The main provider registers first, so honoring the override in `bootstrap.ts` alone would have indexed through one model while querying through another. The pipeline now accepts the embedder explicitly and falls back to the registry scan only when none is supplied, keeping existing callers working.

The two halves have to ship together — fixing only `bootstrap.ts` would make the mismatch worse rather than better.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue

None — found while investigating hybrid retrieval recall.

## Checklist
- [x] Tests added/updated for changes
- [x] Documentation updated (if adding features) — n/a, no new features or config surface
- [x] `npx changeset` run for user-facing changes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes
- [x] No new `any` types introduced
- [x] Error messages are actionable (include what went wrong + how to fix)

## Breaking Changes

None. The migration runs in place on existing databases and preserves all rows. Behavior only changes where it was previously broken: `embeddingProvider` now takes effect where it was ignored, which was a configuration that produced a mismatched index.

## Test Plan

16 new tests across three files.

**`packages/core/tests/storage/fts-stemming.test.ts`** — five parameterized cases for terms that scored zero before; exact surface forms still match; unrelated terms still don't. Plus a migration test that builds a pre-migration `unicode61` index with rows, stamps migrations 001–008 as applied, runs the migration over it, and asserts the old rows both survive and become stemmable.

**`packages/core/tests/ingest/embedder-routing.test.ts`** — registers a tracking embedder in the registry first (mirroring bootstrap's order), passes a different one explicitly, and asserts the supplied one is used and the registered one is not. Also covers the registry fallback and the no-embedder-at-all error path.

**`packages/server/tests/embedding-provider-override.test.ts`** — the override decision itself: routes when different, no-ops when unset, empty, or naming the main provider, and still routes when the main provider cannot embed.

Full suite: build 26/26, tests 51/51, typecheck 50/50.

Happy to split this into two PRs if you'd prefer them reviewed separately.
